### PR TITLE
Use TLS instead of STARTTLS for Mastodons SMTP

### DIFF
--- a/configuration.nix
+++ b/configuration.nix
@@ -224,6 +224,10 @@ in
         MAX_DISPLAY_NAME_CHARS = "100";
         MAX_BIO_CHARS = "1000";
         MAX_PROFILE_FIELDS = "10";
+
+        SMTP_ENABLE_STARTTLS_AUTO = "false";
+        SMTP_ENABLE_STARTTLS = "never";
+        SMTP_TLS = "true";
       };
     };
 


### PR DESCRIPTION
Right now no E-Mails are being sent due to an timeout since it tries to to STARTTLS, this PR sets it to use "normal" tls from the start.