### PR TITLE
Fix failing backups due to no permissions on redis config

### DIFF
--- a/configuration.nix
+++ b/configuration.nix
@@ -373,7 +373,7 @@ in
     postgresDatabases = [ mastoConfig.database.name ];
     paths = [
       "/var/lib/mastodon/public-system/media_attachments" # Hardcoded in the NixOS module
-      config.services.redis.servers.mastodon.settings.dir # Mastodon advised: https://docs.joinmastodon.org/admin/backups/#redis
+      (config.services.redis.servers.mastodon.settings.dir + "/dump.rdb") # Mastodon advised: https://docs.joinmastodon.org/admin/backups/#redis
     ];
     targets = [{
       user = "cutiessocial";


### PR DESCRIPTION
As of https://github.com/NixOS/nixpkgs/pull/200319, the redis config is copied to the redis runtime directory with 0600 permissions. Since changing these permissions would not only require a significant amount of work, but the config file does also not contain anything important. So limiting on the redis dump seems sensible