### PR TITLE
update nixos to 23.11 and thus mastodon to 4.2.3

### DIFF
--- a/configuration.nix
+++ b/configuration.nix
@@ -160,7 +160,7 @@ in
   users.mutableUsers = true;
   users.users = {
     root = {
-      passwordFile = config.sops.secrets."root_password".path;
+      hashedPasswordFile = config.sops.secrets."root_password".path;
     };
     isa = {
       isNormalUser = true;
@@ -201,6 +201,7 @@ in
       localDomain = "cuties.social";
       configureNginx = true;
       automaticMigrations = true;
+      streamingProcesses = 3;
 
       secretKeyBaseFile = secrets."mastodon/secret_key".path;
       vapidPrivateKeyFile = secrets."mastodon/vapid/private_key".path;

--- a/flake.lock
+++ b/flake.lock
@@ -2,11 +2,11 @@
   "nodes": {
     "nixpkgs": {
       "locked": {
-        "lastModified": 1702233072,
-        "narHash": "sha256-H5G2wgbim2Ku6G6w+NSaQaauv6B6DlPhY9fMvArKqRo=",
+        "lastModified": 1704420045,
+        "narHash": "sha256-C36QmoJd5tdQ5R9MC1jM7fBkZW9zBUqbUCsgwS6j4QU=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "781e2a9797ecf0f146e81425c822dca69fe4a348",
+        "rev": "c1be43e8e837b8dbee2b3665a007e761680f0c3d",
         "type": "github"
       },
       "original": {
@@ -18,11 +18,11 @@
     },
     "nixpkgs-stable": {
       "locked": {
-        "lastModified": 1700905716,
-        "narHash": "sha256-w1vHn2MbGfdC+CrP3xLZ3scsI06N0iQLU7eTHIVEFGw=",
+        "lastModified": 1704290814,
+        "narHash": "sha256-LWvKHp7kGxk/GEtlrGYV68qIvPHkU9iToomNFGagixU=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "dfb95385d21475da10b63da74ae96d89ab352431",
+        "rev": "70bdadeb94ffc8806c0570eb5c2695ad29f0e421",
         "type": "github"
       },
       "original": {
@@ -46,11 +46,11 @@
         "nixpkgs-stable": "nixpkgs-stable"
       },
       "locked": {
-        "lastModified": 1701127353,
-        "narHash": "sha256-qVNX0wOl0b7+I35aRu78xUphOyELh+mtUp1KBx89K1Q=",
+        "lastModified": 1704753304,
+        "narHash": "sha256-9shh5fYLfLJrxr4NnIoWcO9T3bTFuO5QW9v/wDpq9Xg=",
         "owner": "Mic92",
         "repo": "sops-nix",
-        "rev": "b1edbf5c0464b4cced90a3ba6f999e671f0af631",
+        "rev": "0ded57412079011f1210c2fcc10e112427d4c0e6",
         "type": "github"
       },
       "original": {

--- a/flake.lock
+++ b/flake.lock
@@ -2,16 +2,16 @@
   "nodes": {
     "nixpkgs": {
       "locked": {
-        "lastModified": 1701268161,
-        "narHash": "sha256-hL4jGGwMHHmyx6G9wi6IrYa8RLkoEtzCb4zWITH1B40=",
+        "lastModified": 1702233072,
+        "narHash": "sha256-H5G2wgbim2Ku6G6w+NSaQaauv6B6DlPhY9fMvArKqRo=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "67be70a859530f6f7c358568eaa6ab0d84b36b01",
+        "rev": "781e2a9797ecf0f146e81425c822dca69fe4a348",
         "type": "github"
       },
       "original": {
         "owner": "NixOS",
-        "ref": "nixos-23.05",
+        "ref": "nixos-23.11",
         "repo": "nixpkgs",
         "type": "github"
       }

--- a/flake.nix
+++ b/flake.nix
@@ -1,6 +1,6 @@
 {
   inputs = {
-    nixpkgs.url = "github:NixOS/nixpkgs/nixos-23.05";
+    nixpkgs.url = "github:NixOS/nixpkgs/nixos-23.11";
     sops-nix = {
       url = "github:Mic92/sops-nix";
       inputs.nixpkgs.follows = "nixpkgs";

--- a/packages/default.nix
+++ b/packages/default.nix
@@ -1,22 +1,11 @@
 final: prev:
 rec {
-  patchedMastodonSource = final.applyPatches {
-    inherit (prev.mastodon.src) src;
-    /* src = prev.fetchFromGitHub {
-      owner = "mastodon";
-      repo = "mastodon";
-      rev = "v${prev.mastodon.version}";
-      sha256 = "sha256-/lyniar3TaQiDTaSKhfI6AF80sjo57VCjTydjv3T6kA=";
-    }; */
+  mastodon = prev.mastodon.override {
+    pname = "mastodon-cuties-socal";
     patches = [
       ./mastodon/allpatches.patch
       ./mastodon/troet.patch
     ];
-  };
-
-  mastodon = prev.mastodon.override {
-    pname = "mastodon-cuties-socal";
-    srcOverride = patchedMastodonSource;
   };
 
   customEmojis = prev.stdenv.mkDerivation {

--- a/packages/mastodon/allpatches.patch
+++ b/packages/mastodon/allpatches.patch
@@ -1,35 +1,17 @@
-diff --git a/app/javascript/mastodon/components/animated_number.js b/app/javascript/mastodon/components/animated_number.js
-index b1aebc73e..de5887e40 100644
---- a/app/javascript/mastodon/components/animated_number.js
-+++ b/app/javascript/mastodon/components/animated_number.js
-@@ -6,13 +6,7 @@ import spring from 'react-motion/lib/spring';
- import { reduceMotion } from 'mastodon/initial_state';
- 
- const obfuscatedCount = count => {
--  if (count < 0) {
--    return 0;
--  } else if (count <= 1) {
--    return count;
--  } else {
--    return '1+';
--  }
-+  return Math.max(0, count);
- };
- 
- export default class AnimatedNumber extends React.PureComponent {
-diff --git a/app/javascript/mastodon/features/compose/components/compose_form.js b/app/javascript/mastodon/features/compose/components/compose_form.js
-index 6a65f44da..e07f19083 100644
---- a/app/javascript/mastodon/features/compose/components/compose_form.js
-+++ b/app/javascript/mastodon/features/compose/components/compose_form.js
-@@ -20,6 +20,8 @@ import { isMobile } from '../../../is_mobile';
- import ImmutablePureComponent from 'react-immutable-pure-component';
+diff --git a/app/javascript/mastodon/features/compose/components/compose_form.jsx b/app/javascript/mastodon/features/compose/components/compose_form.jsx
+index b15fe2909..73903464e 100644
+--- a/app/javascript/mastodon/features/compose/components/compose_form.jsx
++++ b/app/javascript/mastodon/features/compose/components/compose_form.jsx
+@@ -11,6 +11,9 @@ import ImmutablePureComponent from 'react-immutable-pure-component';
+ import { ReactComponent as LockIcon } from '@material-symbols/svg-600/outlined/lock.svg';
  import { length } from 'stringz';
- import { countableText } from '../util/counter';
+
 +import initialState from '../../../initial_state';
 +const maxChars = initialState.max_toot_chars;
- import Icon from 'mastodon/components/icon';
- 
- const allowedAroundShortCode = '><\u0085\u0020\u00a0\u1680\u2000\u2001\u2002\u2003\u2004\u2005\u2006\u2007\u2008\u2009\u200a\u202f\u205f\u3000\u2028\u2029\u0009\u000a\u000b\u000c\u000d';
++
+ import { Icon }  from 'mastodon/components/icon';
+ import { WithOptionalRouterPropTypes, withOptionalRouter } from 'mastodon/utils/react_router';
+
 @@ -90,7 +92,7 @@ class ComposeForm extends ImmutablePureComponent {
      const fulltext = this.getFulltextForCharacterCounting();
      const isOnlyWhitespace = fulltext.length !== 0 && fulltext.trim().length === 0;
@@ -39,29 +21,30 @@ index 6a65f44da..e07f19083 100644
    };
  
    handleSubmit = (e) => {
-@@ -277,7 +279,7 @@ class ComposeForm extends ImmutablePureComponent {
-           </div>
- 
-           <div className='character-counter__wrapper'>
--            <CharacterCounter max={500} text={this.getFulltextForCharacterCounting()} />
-+            <CharacterCounter max={maxChars} text={this.getFulltextForCharacterCounting()} />
+@@ -297,7 +300,7 @@ class ComposeForm extends ImmutablePureComponent {
+             </div>
+
+             <div className='character-counter__wrapper'>
+-              <CharacterCounter max={500} text={this.getFulltextForCharacterCounting()} />
++              <CharacterCounter max={maxChars} text={this.getFulltextForCharacterCounting()} />
+             </div>
            </div>
          </div>
- 
-diff --git a/app/javascript/mastodon/features/compose/components/poll_form.js b/app/javascript/mastodon/features/compose/components/poll_form.js
+diff --git a/app/javascript/mastodon/features/compose/components/poll_form.jsx b/app/javascript/mastodon/features/compose/components/poll_form.jsx
 index ede29b8a0..e84a89c51 100644
---- a/app/javascript/mastodon/features/compose/components/poll_form.js
-+++ b/app/javascript/mastodon/features/compose/components/poll_form.js
-@@ -6,6 +6,9 @@ import { defineMessages, injectIntl, FormattedMessage } from 'react-intl';
- import IconButton from 'mastodon/components/icon_button';
- import Icon from 'mastodon/components/icon';
- import AutosuggestInput from 'mastodon/components/autosuggest_input';
+--- a/app/javascript/mastodon/features/compose/components/poll_form.jsx
++++ b/app/javascript/mastodon/features/compose/components/poll_form.jsx
+@@ -15,6 +15,10 @@ import AutosuggestInput from 'mastodon/components/autosuggest_input';
+ import { Icon }  from 'mastodon/components/icon';
+ import { IconButton } from 'mastodon/components/icon_button';
+
 +import initialState from '../../../initial_state';
 +const maxOptions = initialState.max_poll_options;
 +const minOptions = initialState.min_poll_options;
- import classNames from 'classnames';
- 
++
  const messages = defineMessages({
+   option_placeholder: { id: 'compose_form.poll.option_placeholder', defaultMessage: 'Choice {number}' },
+   add_option: { id: 'compose_form.poll.add_option', defaultMessage: 'Add a choice' },
 @@ -102,7 +105,7 @@ class Option extends React.PureComponent {
          </label>
  
@@ -94,8 +77,8 @@ index fc7359cfc..ce65eab57 100644
 +
    validates :username, presence: true
    validates_with UniqueUsernameValidator, if: -> { will_save_change_to_username? }
- 
-@@ -90,9 +94,9 @@ class Account < ApplicationRecord
+
+@@ -100,9 +100,9 @@ class Account < ApplicationRecord
    # Local user validations
    validates :username, format: { with: /\A[a-z0-9_]+\z/i }, length: { maximum: 30 }, if: -> { local? && will_save_change_to_username? && actor_type != 'Application' }
    validates_with UnreservedUsernameValidator, if: -> { local? && will_save_change_to_username? && actor_type != 'Application' }
@@ -105,9 +88,10 @@ index fc7359cfc..ce65eab57 100644
 +  validates :display_name, length: { maximum: MAX_DISPLAY_NAME_LENGTH }, if: -> { local? && will_save_change_to_display_name? }
 +  validates :note, note_length: { maximum: MAX_NOTE_LENGTH }, if: -> { local? && will_save_change_to_note? }
 +  validates :fields, length: { maximum: MAX_FIELDS }, if: -> { local? && will_save_change_to_fields? }
- 
-   scope :remote, -> { where.not(domain: nil) }
-   scope :local, -> { where(domain: nil) }
+   validates :uri, absence: true, if: :local?, on: :create
+   validates :inbox_url, absence: true, if: :local?, on: :create
+   validates :shared_inbox_url, absence: true, if: :local?, on: :create 
+
 @@ -324,7 +328,7 @@ class Account < ApplicationRecord
      self[:fields] = fields
    end
@@ -214,20 +198,22 @@ index e107912b7..12d1c0953 100644
    URL_PLACEHOLDER = 'x' * 23
  
 diff --git a/app/views/settings/profiles/show.html.haml b/app/views/settings/profiles/show.html.haml
-index 3067b3737..a6d698f54 100644
+index 5f9613c93..fbd36b7f5 100644
 --- a/app/views/settings/profiles/show.html.haml
 +++ b/app/views/settings/profiles/show.html.haml
-@@ -9,8 +9,8 @@
- 
-   .fields-row
-     .fields-row__column.fields-group.fields-row__column-6
--      = f.input :display_name, wrapper: :with_label, input_html: { maxlength: 30, data: { default: @account.username } }, hint: false
--      = f.input :note, wrapper: :with_label, input_html: { maxlength: 500 }, hint: false
-+      = f.input :display_name, wrapper: :with_label, input_html: { maxlength: Account::MAX_DISPLAY_NAME_LENGTH, data: { default: @account.username } }, hint: false
-+      = f.input :note, wrapper: :with_label, input_html: { maxlength: Account::MAX_NOTE_LENGTH }, hint: false
- 
+@@ -15,10 +15,10 @@
    .fields-row
      .fields-row__column.fields-row__column-6
+       .fields-group
+-        = f.input :display_name, wrapper: :with_block_label, input_html: { maxlength: 30, data: { default: @account.username } }
++        = f.input :display_name, wrapper: :with_block_label, input_html: { maxlength: Account::MAX_DISPLAY_NAME_LENGTH, data: { default: @account.username } }
+
+       .fields-group
+-        = f.input :note, wrapper: :with_block_label, input_html: { maxlength: 500 }
++        = f.input :note, wrapper: :with_block_label, input_html: { maxlength: Account::MAX_NOTE_LENGTH }
+
+     .fields-row__column.fields-group.fields-row__column-6
+       .input.with_block_label
 diff --git a/spec/models/account_spec.rb b/spec/models/account_spec.rb
 index edae05f9d..4d6357fe4 100644
 --- a/spec/models/account_spec.rb

--- a/packages/mastodon/troet.patch
+++ b/packages/mastodon/troet.patch
@@ -1,14 +1,13 @@
 diff --git a/app/javascript/mastodon/locales/de.json b/app/javascript/mastodon/locales/de.json
-index 223e68912..90dd1175c 100644
+index cf545e48c..4953bdfba 100644
 --- a/app/javascript/mastodon/locales/de.json
 +++ b/app/javascript/mastodon/locales/de.json
-@@ -137,7 +137,7 @@
+@@ -151,7 +151,7 @@
    "compose_form.poll.remove_option": "Auswahlfeld entfernen",
    "compose_form.poll.switch_to_multiple": "Mehrfachauswahl erlauben",
    "compose_form.poll.switch_to_single": "Nur Einzelauswahl erlauben",
 -  "compose_form.publish": "Veröffentlichen",
 +  "compose_form.publish": "Tröt",
--  "compose_form.publish_form": "Veröffentlichen",
-+  "compose_form.publish_form": "Tröt",
+   "compose_form.publish_form": "Neuer Beitrag",
    "compose_form.publish_loud": "{publish}!",
    "compose_form.save_changes": "Änderungen speichern",


### PR DESCRIPTION
```
nix store diff-closures ./result-23.05 ./result-23.11
SDL2: 2.26.5 → 2.28.4
X-Restart-Triggers-nix: ∅ → ε
X-Restart-Triggers-reload-systemd-vconsole: ∅ → ε
X-Restart-Triggers-systemd: ∅ → ε
X-Restart-Triggers-systemd-journald-: ∅ → ε
X-Restart-Triggers-systemd-modules: ∅ → ε
alertmanager: 0.25.1 → 0.26.0, +1423.6 KiB
alsa-lib: 1.2.8 → 1.2.9
alsa-ucm-conf: 1.2.9 → 1.2.10, +24.1 KiB
audit: 3.1 → 3.1.2, +63.3 KiB
aws-c-auth: 0.6.26 → 0.7.0, +21.1 KiB
aws-c-cal: 0.5.21 → 0.6.0, +30.4 KiB
aws-c-common: 0.8.15 → 0.8.23, +8.7 KiB
aws-c-compression: 0.2.16 → 0.2.17
aws-c-event-stream: 0.2.20 → 0.3.1
aws-c-http: 0.7.6 → 0.7.11, +9.6 KiB
aws-c-io: 0.13.19 → 0.13.29, +75.2 KiB
aws-c-mqtt: 0.8.8 → 0.8.14, +18.5 KiB
aws-c-s3: 0.2.8 → 0.3.13, +35.0 KiB
aws-c-sdkutils: 0.1.9 → 0.1.12
aws-checksums: 0.1.14 → 0.1.17
aws-crt-cpp: 0.19.8 → 0.20.3
aws-sdk-cpp: 1.11.37 → 1.11.118
bash: -41.3 KiB
bash-interactive: -49.4 KiB
bat: 0.23.0 → 0.24.0, +823.5 KiB
binutils: ∅ → 2.40, +31676.1 KiB
binutils-wrapper: ∅ → 2.40, +50.1 KiB
bluez: 5.66 → 5.70, +746.5 KiB
bootspec: ∅ → 1.0.0, +1980.0 KiB
brotli: 1.0.9 → 1.1.0, -1612.6 KiB
btrfs-progs: 6.3 → 6.6.2, +673.9 KiB
bundler: 2.4.13 → 2.4.22, +32.6 KiB
cairo: 1.16.0 → 1.18.0, -95.4 KiB
coreutils: 9.1 → 9.3, +22.1 KiB
coreutils-full: 9.1 → 9.3, +681.6 KiB
cryptsetup: -18.2 KiB
curl: 8.1.1 → 8.4.0, +52.4 KiB
dav1d: 1.2.0 → 1.2.1, -40.8 KiB
dbus: 1.14.8 → 1.14.10
diffutils: 3.9 → 3.10
e2fsprogs: 1.46.6 → 1.47.0, +39.2 KiB
elfutils: 0.189 → 0.190, +43.3 KiB
ell: 0.56 → 0.59
envsubst: -65.0 KiB
etc: 60-nixos.conf → ∅
etc-coredump.conf: ε → ∅
etc-firmware.conf: ε → ∅
etc-journald.conf: ε → ∅
etc-logind.conf: ε → ∅
etc-lvm-lvm.conf: ∅ → ε
etc-lvm.conf: ε → ∅
etc-mdadm.conf: ∅ → ε
etc-modprobe.d-firmware.conf: ∅ → ε
etc-modprobe.d-nixos.conf: ∅ → ε
etc-nix-registry.json: ∅ → ε
etc-nixos.conf: ε → ∅
etc-oomd.conf: ε → ∅
etc-pam: ∅ → ε
etc-registry.json: ε → ∅
etc-sleep.conf: ε → ∅
etc-ssh-ssh_config: ∅ → ε
etc-ssh-ssh_known_hosts: ∅ → ε
etc-ssh_config: ε → ∅
etc-ssh_known_hosts: ε → ∅
etc-sysctl.d: ∅ → 60-nixos.conf
etc-system.conf: ε → ∅
etc-systemd-coredump.conf: ∅ → ε
etc-systemd-journald.conf: ∅ → ε
etc-systemd-logind.conf: ∅ → ε
etc-systemd-oomd.conf: ∅ → ε
etc-systemd-sleep.conf: ∅ → ε
etc-systemd-system.conf: ∅ → ε
etc-systemd-timesyncd.conf: ∅ → ε
etc-systemd-user.conf: ∅ → ε
etc-timesyncd.conf: ε → ∅
etc-user.conf: ε → ∅
expand-response: ∅ → ε, +17.0 KiB
expat: -107.7 KiB
extra: ∅ → ε, +24186.9 KiB
fd: 8.7.0 → 8.7.1, +90.7 KiB
ffado: ∅ → 2.4.7, +5225.8 KiB
ffmpeg: 5.1.3 → 6.0, +201.0 KiB
ffmpeg-headless: 5.1.3 → 6.0, +144.8 KiB
file: 5.44 → 5.45, +258.5 KiB
flac: 1.4.2 → 1.4.3
flock: ∅ → 0.4.0, +20.3 KiB
fontconfig: 2.14.0 → 2.14.2, +45.0 KiB
freetype: 2.13.0 → 2.13.2
fribidi: 1.0.12 → 1.0.13
fuse: 3.11.0 → 3.16.2, +18.4 KiB
gawk: 5.2.1 → 5.2.2, +144.7 KiB
gcc: 12.2.0 → 12.3.0, +213291.3 KiB
gcc-wrapper: ∅ → 12.3.0, +60.5 KiB
getent-glibc: 2.37-45 → 2.38-27
gettext: 0.21 → 0.21.1, +228.5 KiB
gfortran: 12.2.0 → ∅, -10855.1 KiB
glib: 2.76.2 → 2.78.1, +201.1 KiB
glibc: 2.37-45 → 2.38-27, +21.0 KiB
glibc-iconv: 2.37 → 2.38
glibc-locales: 2.37-45 → 2.38-27
glibmm: ∅ → 2.66.6, +4208.3 KiB
gmp: ∅ → 6.3.0, +699.1 KiB
gmp-with-cxx: 6.2.1 → 6.3.0, +25.2 KiB
gnugrep: 3.7 → 3.11, +159.1 KiB
gnum4: ∅ → 1.4.19, +815.3 KiB
gnupg: 2.4.0 → 2.4.1
gnutls: 3.8.0 → 3.8.2, +27.9 KiB
groff: 1.22.4 → 1.23.0, +345.2 KiB
gst-plugins-base: 1.22.6 → 1.22.7
gstreamer: 1.22.6 → 1.22.7
gzip: 1.12 → 1.13, +8.4 KiB
harfbuzz: 7.2.0 → 7.3.0, +9.5 KiB
hwdata: 0.370 → 0.376, +169.3 KiB
hwdb.bin: +212.2 KiB
icu4c: 73.1 → 73.2, +33.7 KiB
imagemagick: 7.1.1-19 → 7.1.1-21
inetutils: +11.1 KiB
initrd: ∅ → ε
initrd-kmod-blacklist: ∅ → ε
initrd-linux: 6.1.64 → 6.1.66, +277.0 KiB
iproute2: 6.3.0 → 6.5.0, +87.9 KiB
iptables: 1.8.9 → 1.8.10
isl: ∅ → 0.20, +2513.2 KiB
iso-codes: 4.11.0 → 4.15.0, +331.3 KiB
jemalloc: +1209.4 KiB
jq: 1.6 → 1.7, +131.1 KiB
kbd: 2.5.1 → 2.6.3
keymap: ∅ → ε
kmod: 30 → 31, +8.6 KiB
ldns: ∅ → 1.8.3, +593.0 KiB
lego: 4.11.0 → 4.14.2, +8569.3 KiB
less: 608 → 643, +22.2 KiB
lesspipe: 2.07 → 2.10
libGL: 1.6.0 → 1.7.0
libICE: 1.0.10 → 1.1.1
libSM: 1.2.3 → 1.2.4
libXScrnSaver: 1.2.3 → 1.2.4
libXau: 1.0.9 → 1.0.11
libXcursor: 1.2.0 → 1.2.1, +9.8 KiB
libXdmcp: 1.1.3 → 1.1.4
libXext: 1.3.4 → 1.3.5
libXfixes: 6.0.0 → 6.0.1
libXft: 2.3.6 → 2.3.8
libXi: 1.8 → 1.8.1
libXinerama: 1.1.4 → 1.1.5
libXmu: 1.1.3 → 1.1.4
libXrandr: 1.5.2 → 1.5.4
libXrender: 0.9.10 → 0.9.11, +20.5 KiB
libXt: 1.2.1 → 1.3.0
libXv: 1.0.11 → 1.0.12
libaom: 3.6.0 → 3.7.0, -67.4 KiB
libapparmor: -9.0 KiB
libarchive: 3.6.2 → 3.7.2, +43.7 KiB
libargon2: ∅ → 20190702, +137.0 KiB
libass: -43.5 KiB
libassuan: 2.5.5 → 2.5.6
libavc1394: ∅ → 0.5.4, +141.1 KiB
libavif: 0.11.1 → 1.0.1, +102.3 KiB
libbpf: 1.2.0 → 1.2.2
libbsd-unstable: ∅ → 2023-04-29, +100.0 KiB
libcamera: -102.7 KiB
libcap-ng: -26.7 KiB
libcbor-unstable: -82.2 KiB
libconfig: ∅ → 1.7.3, +374.5 KiB
libcpuid: 0.6.3 → 0.6.4, +28.7 KiB
libdaemon: -31.5 KiB
libdeflate: 1.18 → 1.19
libdrm: 2.4.115 → 2.4.117
libffi: +16.7 KiB
libglvnd: 1.6.0 → 1.7.0, -2214.6 KiB
libhwy: 1.0.4 → 1.0.7, +3639.5 KiB
libical: 3.0.16 → 3.0.17
libiec61883: ∅ → 1.2.0, +142.8 KiB
libimagequant: 4.2.0 → 4.2.2, -1561.5 KiB
libjack2: 1.9.19 → 1.9.22, -190.4 KiB
libjxl: +4784.5 KiB
liblc3: 1.0.2 → 1.0.4
libmd: ∅ → 1.1.0, +125.7 KiB
libmpc: ∅ → 1.3.1, +273.9 KiB
libmpg123: 1.31.3 → 1.32.3, +16.1 KiB
libmysofa: 1.3.1 → 1.3.2
libnftnl: 1.2.5 → 1.2.6
libopus: 1.3.1 → 1.4
libpciaccess: 0.16 → 0.17
libpng-apng: 1.6.39 → 1.6.40
libraw1394: ∅ → 2.1.2, +191.9 KiB
libressl: 3.7.3 → 3.8.2, -265.9 KiB
librsvg: 2.55.3 → 2.57.0, -11436.8 KiB
libsamplerate: ∅ → 0.1.9, +1556.0 KiB
libsecret: 0.20.5 → 0.21.1, +11.8 KiB
libsigc++: ∅ → 2.12.1, +1182.4 KiB
libsndfile: 1.2.0 → 1.2.2
libtiff: 4.5.1 → 4.6.0, -499.2 KiB
liburcu: 0.14.0 → ∅, -772.9 KiB
libuv: 1.44.2 → 1.46.0
libva: 2.18.0 → 2.20.0
libva-minimal: 2.18.0 → 2.20.0
libvisual: -215.2 KiB
libvpx: +25.6 KiB
libxcb: 1.14 → 1.16, +85.0 KiB
libxcrypt: 4.4.33 → 4.4.36
libxml++: ∅ → 3.0.1, +297.2 KiB
libxml2: 2.10.4 → 2.11.5, -43.6 KiB
libxslt: 1.1.37 → 1.1.38
libyaml: -54.1 KiB
lilv: 0.24.12 → 0.24.20, +107.2 KiB
lingering: ∅ → ε
link: ∅ → ε
linux: 6.1.64, 6.1.64-modules → 6.1.66, 6.1.66-modules, +76.6 KiB
linux-headers: 6.2 → 6.5, +128.7 KiB
linux-headers-static: ∅ → 6.5, +6353.1 KiB
lm-sensors: +302.4 KiB
lttng-ust: 2.13.1 → 2.13.6, -228.3 KiB
lvm2: 2.03.21 → 2.03.22, +25.1 KiB
make-initrd-ng: +118.5 KiB
mastodon-cuties-socal: 4.1.10 → 4.2.3, +1490.8 KiB
mastodon-cuties-socal-gems: 4.1.10 → 4.2.3, +17845.6 KiB
mastodon-cuties-socal-modules: 4.1.10 → 4.2.3, +20260.9 KiB
mdadm.conf: ∅ → ε
mkpasswd: 5.5.17 → 5.5.20
mpfr: ∅ → 4.2.1, +774.6 KiB
nettle: 3.8.1 → 3.9.1, +31.3 KiB
nghttp2: 1.51.0 → 1.57.0, -70.9 KiB
nix: 2.13.6 → 2.15.3, 2.18.1, +25864.2 KiB
nixos: +234.4 KiB
nixos-firewall: ∅ → ε
nixos-system-kuschelhaufen: 23.05.20231129.67be70a → 23.11.20231210.781e2a9
nlohmann_json: 3.11.2 → ∅, -904.0 KiB
node_exporter: 1.5.0 → 1.7.0, -183.7 KiB
nodejs-slim: 18.17.1 → 20.9.0, +4220.5 KiB
nsncd-unstable: 2022-11-14 → 2023-10-26, +22.8 KiB
nss-cacert: 3.92, 3.92-p11kit → 3.95, 3.95-p11kit, -26.2 KiB
oniguruma: 6.9.8 → 6.9.9, +12.7 KiB
openfec: 1.4.2 → 1.4.2.9
openjdk-headless: -38.5 KiB
openresolv: 3.12.0 → 3.13.2
openssh: 9.3p2 → 9.5p1, +64.9 KiB
openssl: -6344.4 KiB
orc: 0.4.33 → 0.4.34, -39.8 KiB
p11-kit: 0.24.1 → 0.25.0, +1303.7 KiB
pango: 1.50.14 → 1.51.0
pciutils: 3.9.0 → 3.10.0, +38.7 KiB
perl: 5.36.0 → 5.38.0, +3869.4 KiB
perl5.36.0-Config-IniFiles: 3.000003 → ∅, -91.2 KiB
perl5.36.0-DBD-SQLite: 1.70 → ∅, -421.1 KiB
perl5.36.0-DBI: 1.643 → ∅, -1741.8 KiB
perl5.36.0-File-Slurp: 9999.32 → ∅, -33.5 KiB
perl5.36.0-IO-Stringy: 2.113 → ∅, -77.5 KiB
perl5.36.0-JSON: 4.02 → ∅, -171.4 KiB
perl5.36.0-String-ShellQuote: 1.04 → ∅, -16.3 KiB
perl5.38.0-Config-IniFiles: ∅ → 3.000003, +91.2 KiB
perl5.38.0-DBD-SQLite: ∅ → 1.74, +427.0 KiB
perl5.38.0-DBI: ∅ → 1.643, +1733.0 KiB
perl5.38.0-File-Slurp: ∅ → 9999.32, +33.5 KiB
perl5.38.0-IO-Stringy: ∅ → 2.113, +77.5 KiB
perl5.38.0-JSON: ∅ → 4.10, +174.7 KiB
perl5.38.0-String-ShellQuote: ∅ → 1.04, +16.1 KiB
pipewire: 0.3.71 → 0.3.85, +2435.9 KiB
postgresql: 14.9 → 14.10, 15.5, +29568.5 KiB
prometheus: 2.44.0 → 2.48.0, +3977.7 KiB
python3: 3.10.13 → 3.11.6, +32646.9 KiB
python3.10-attrs: 22.2.0 → ∅, -340.8 KiB
python3.10-defusedxml: 0.7.1 → ∅, -104.6 KiB
python3.10-docopt: 0.6.2 → ∅, -62.5 KiB
python3.10-olefile: 0.46 → ∅, -176.2 KiB
python3.10-packaging: 23.0 → ∅, -241.2 KiB
python3.10-pillow: 9.4.0 → ∅, -2459.7 KiB
python3.10-psutil: 5.9.5 → ∅, -1561.8 KiB
python3.10-six: 1.16.0 → ∅, -67.7 KiB
python3.10-ueberzug: 18.1.9 → ∅, -257.5 KiB
python3.10-xlib: 0.33 → ∅, -1155.0 KiB
python3.11-attrs: ∅ → 23.1.0, +590.5 KiB
python3.11-defusedxml: ∅ → 0.7.1, +165.1 KiB
python3.11-docopt: ∅ → 0.6.2, +115.3 KiB
python3.11-olefile: ∅ → 0.46, +305.7 KiB
python3.11-pillow: ∅ → 10.1.0, +4301.3 KiB
python3.11-psutil: ∅ → 5.9.6, +3462.5 KiB
python3.11-six: ∅ → 1.16.0, +130.7 KiB
python3.11-ueberzug: ∅ → 18.1.9, +495.9 KiB
python3.11-xlib: ∅ → 0.33, +2204.1 KiB
rav1e: 0.6.4 → 0.6.6, -86752.2 KiB
rclone: 1.62.2 → 1.64.2, +7901.2 KiB
redis: 7.0.14 → 7.2.3, -1036.3 KiB
restic: 0.15.2 → 0.16.2, +1856.6 KiB
ripgrep: +70.1 KiB
roc-toolkit: 0.2.3 → 0.2.5, +59.1 KiB
ruby: 3.0.6 → 3.2.2, +7028.3 KiB
ruby3.0.6-actioncable: 6.1.7.6 → ∅, -163.7 KiB
ruby3.0.6-actionmailbox: 6.1.7.6 → ∅, -86.5 KiB
ruby3.0.6-actionmailer: 6.1.7.6 → ∅, -107.3 KiB
ruby3.0.6-actionpack: 6.1.7.6 → ∅, -860.0 KiB
ruby3.0.6-actiontext: 6.1.7.6 → ∅, -68.6 KiB
ruby3.0.6-actionview: 6.1.7.6 → ∅, -738.4 KiB
ruby3.0.6-active_model_serializers: 0.10.13 → ∅, -247.4 KiB
ruby3.0.6-active_record_query_trace: 1.8 → ∅, -14.8 KiB
ruby3.0.6-activejob: 6.1.7.6 → ∅, -132.1 KiB
ruby3.0.6-activemodel: 6.1.7.6 → ∅, -264.1 KiB
ruby3.0.6-activerecord: 6.1.7.6 → ∅, -1867.9 KiB
ruby3.0.6-activestorage: 6.1.7.6 → ∅, -233.6 KiB
ruby3.0.6-activesupport: 6.1.7.6 → ∅, -882.1 KiB
ruby3.0.6-addressable: 2.8.1 → ∅, -545.7 KiB
ruby3.0.6-aes_key_wrap: 1.1.0 → ∅, -17.7 KiB
ruby3.0.6-airbrussh: 1.4.1 → ∅, -58.0 KiB
ruby3.0.6-android_key_attestation: 0.3.0 → ∅, -34.5 KiB
ruby3.0.6-annotate: 3.2.0 → ∅, -132.0 KiB
ruby3.0.6-ast: 2.4.2 → ∅, -28.5 KiB
ruby3.0.6-attr_encrypted: 3.1.0 → ∅, -131.4 KiB
ruby3.0.6-attr_required: 1.0.1 → ∅, -22.3 KiB
ruby3.0.6-awrence: 1.2.1 → ∅, -14.8 KiB
ruby3.0.6-aws-eventstream: 1.2.0 → ∅, -34.7 KiB
ruby3.0.6-aws-partitions: 1.701.0 → ∅, -842.2 KiB
ruby3.0.6-aws-sdk-core: 3.170.0 → ∅, -1255.1 KiB
ruby3.0.6-aws-sdk-kms: 1.62.0 → ∅, -859.7 KiB
ruby3.0.6-aws-sdk-s3: 1.119.0 → ∅, -2425.5 KiB
ruby3.0.6-aws-sigv4: 1.5.2 → ∅, -57.0 KiB
ruby3.0.6-bcrypt: 3.1.17 → ∅, -225.8 KiB
ruby3.0.6-better_errors: 2.9.1 → ∅, -104.3 KiB
ruby3.0.6-better_html: 2.0.1 → ∅, -209.4 KiB
ruby3.0.6-bindata: 2.4.14 → ∅, -345.5 KiB
ruby3.0.6-binding_of_caller: 1.0.0 → ∅, -25.4 KiB
ruby3.0.6-blurhash: 0.1.7 → ∅, -59.0 KiB
ruby3.0.6-bootsnap: 1.16.0 → ∅, -189.4 KiB
ruby3.0.6-brakeman: 5.4.0 → ∅, -10131.2 KiB
ruby3.0.6-browser: 4.2.0 → ∅, -226.2 KiB
ruby3.0.6-brpoplpush-redis_script: 0.1.3 → ∅, -38.7 KiB
ruby3.0.6-builder: 3.2.4 → ∅, -107.9 KiB
ruby3.0.6-bullet: 7.0.7 → ∅, -314.6 KiB
ruby3.0.6-bundler-audit: 0.9.1 → ∅, -218.7 KiB
ruby3.0.6-byebug: 11.1.3 → ∅, -456.2 KiB
ruby3.0.6-capistrano: 3.17.1 → ∅, -299.6 KiB
ruby3.0.6-capistrano-bundler: 2.0.1 → ∅, -22.2 KiB
ruby3.0.6-capistrano-rails: 1.6.2 → ∅, -25.9 KiB
ruby3.0.6-capistrano-rbenv: 2.2.0 → ∅, -16.3 KiB
ruby3.0.6-capistrano-yarn: 2.0.2 → ∅, -14.7 KiB
ruby3.0.6-capybara: 3.38.0 → ∅, -1717.0 KiB
ruby3.0.6-case_transform: 0.2 → ∅, -11.9 KiB
ruby3.0.6-cbor: 0.5.9.6 → ∅, -428.0 KiB
ruby3.0.6-charlock_holmes: 0.7.7 → ∅, -104.8 KiB
ruby3.0.6-chewy: 7.2.4 → ∅, -825.0 KiB
ruby3.0.6-chunky_png: 1.4.0 → ∅, -1255.5 KiB
ruby3.0.6-climate_control: 0.2.0 → ∅, -21.6 KiB
ruby3.0.6-cocoon: 1.2.15 → ∅, -385.7 KiB
ruby3.0.6-coderay: 1.1.3 → ∅, -356.3 KiB
ruby3.0.6-color_diff: 0.1 → ∅, -16.7 KiB
ruby3.0.6-concurrent-ruby: 1.2.2 → ∅, -1173.5 KiB
ruby3.0.6-connection_pool: 2.3.0 → ∅, -25.6 KiB
ruby3.0.6-cose: 1.2.1 → ∅, -58.5 KiB
ruby3.0.6-crack: 0.4.5 → ∅, -18.3 KiB
ruby3.0.6-crass: 1.0.6 → ∅, -61.3 KiB
ruby3.0.6-css_parser: 1.12.0 → ∅, -65.3 KiB
ruby3.0.6-date: 3.3.3 → ∅, -938.2 KiB
ruby3.0.6-debug_inspector: 1.0.0 → ∅, -55.4 KiB
ruby3.0.6-devise: 4.8.1 → ∅, -347.5 KiB
ruby3.0.6-devise-two-factor: 4.0.2 → ∅, -74.2 KiB
ruby3.0.6-devise_pam_authenticatable2: 9.2.0 → ∅, -20.8 KiB
ruby3.0.6-diff-lcs: 1.5.0 → ∅, -202.3 KiB
ruby3.0.6-discard: 1.2.1 → ∅, -36.3 KiB
ruby3.0.6-docile: 1.4.0 → ∅, -43.4 KiB
ruby3.0.6-domain_name: 0.5.20190701 → ∅, -480.8 KiB
ruby3.0.6-doorkeeper: 5.6.6 → ∅, -487.7 KiB
ruby3.0.6-dotenv: 2.8.1 → ∅, -32.0 KiB
ruby3.0.6-dotenv-rails: 2.8.1 → ∅, -21.3 KiB
ruby3.0.6-ed25519: 1.3.0 → ∅, -679.1 KiB
ruby3.0.6-elasticsearch: 7.13.3 → ∅, -47.8 KiB
ruby3.0.6-elasticsearch-api: 7.13.3 → ∅, -893.3 KiB
ruby3.0.6-elasticsearch-dsl: 0.1.10 → ∅, -697.1 KiB
ruby3.0.6-elasticsearch-transport: 7.13.3 → ∅, -306.3 KiB
ruby3.0.6-encryptor: 3.0.0 → ∅, -53.9 KiB
ruby3.0.6-erubi: 1.12.0 → ∅, -29.4 KiB
ruby3.0.6-et-orbi: 1.2.7 → ∅, -49.1 KiB
ruby3.0.6-excon: 0.95.0 → ∅, -358.4 KiB
ruby3.0.6-fabrication: 2.30.0 → ∅, -54.0 KiB
ruby3.0.6-faker: 3.1.1 → ∅, -6552.5 KiB
ruby3.0.6-faraday: 1.9.3 → ∅, -292.5 KiB
ruby3.0.6-faraday-em_http: 1.0.0 → ∅, -20.9 KiB
ruby3.0.6-faraday-em_synchrony: 1.0.0 → ∅, -18.0 KiB
ruby3.0.6-faraday-excon: 1.1.0 → ∅, -14.3 KiB
ruby3.0.6-faraday-httpclient: 1.0.1 → ∅, -15.9 KiB
ruby3.0.6-faraday-multipart: 1.0.3 → ∅, -20.9 KiB
ruby3.0.6-faraday-net_http: 1.0.1 → ∅, -17.6 KiB
ruby3.0.6-faraday-net_http_persistent: 1.2.0 → ∅, -15.5 KiB
ruby3.0.6-faraday-patron: 1.0.0 → ∅, -14.9 KiB
ruby3.0.6-faraday-rack: 1.0.0 → ∅, -13.0 KiB
ruby3.0.6-faraday-retry: 1.0.3 → ∅, -23.0 KiB
ruby3.0.6-fast_blank: 1.0.1 → ∅, -54.6 KiB
ruby3.0.6-fastimage: 2.2.6 → ∅, -44.0 KiB
ruby3.0.6-ffi: 1.15.5 → ∅, -4916.1 KiB
ruby3.0.6-ffi-compiler: 1.0.1 → ∅, -40.6 KiB
ruby3.0.6-fog-core: 2.1.0 → ∅, -232.2 KiB
ruby3.0.6-fog-json: 1.2.0 → ∅, -18.6 KiB
ruby3.0.6-fog-openstack: 0.3.10 → ∅, -1542.5 KiB
ruby3.0.6-formatador: 0.3.0 → ∅, -34.4 KiB
ruby3.0.6-fugit: 1.7.1 → ∅, -86.1 KiB
ruby3.0.6-fuubar: 2.5.1 → ∅, -21.4 KiB
ruby3.0.6-gitlab-omniauth-openid-connect: 0.10.1 → ∅, -92.2 KiB
ruby3.0.6-globalid: 1.1.0 → ∅, -36.7 KiB
ruby3.0.6-hamlit: 2.13.0 → ∅, -346.7 KiB
ruby3.0.6-hamlit-rails: 0.2.3 → ∅, -30.5 KiB
ruby3.0.6-hashdiff: 1.0.1 → ∅, -78.9 KiB
ruby3.0.6-hashie: 5.0.0 → ∅, -198.8 KiB
ruby3.0.6-highline: 2.0.3 → ∅, -370.8 KiB
ruby3.0.6-hiredis: 0.6.3 → ∅, -640.2 KiB
ruby3.0.6-hkdf: 0.3.0 → ∅, -18.3 KiB
ruby3.0.6-htmlentities: 4.3.4 → ∅, -132.9 KiB
ruby3.0.6-http: 5.1.1 → ∅, -317.8 KiB
ruby3.0.6-http-cookie: 1.0.5 → ∅, -164.2 KiB
ruby3.0.6-http-form_data: 2.3.0 → ∅, -59.6 KiB
ruby3.0.6-http_accept_language: 2.1.1 → ∅, -30.6 KiB
ruby3.0.6-httpclient: 2.8.3 → ∅, -911.6 KiB
ruby3.0.6-httplog: 1.6.2 → ∅, -50.5 KiB
ruby3.0.6-i18n: 1.12.0 → ∅, -173.5 KiB
ruby3.0.6-i18n-tasks: 1.0.12 → ∅, -260.5 KiB
ruby3.0.6-idn-ruby: 0.1.5 → ∅, -117.6 KiB
ruby3.0.6-ipaddress: 0.8.3 → ∅, -148.2 KiB
ruby3.0.6-jmespath: 1.6.2 → ∅, -88.1 KiB
ruby3.0.6-json: 2.6.3 → ∅, -479.1 KiB
ruby3.0.6-json-canonicalization: 0.3.0 → ∅, -22.6 KiB
ruby3.0.6-json-jwt: 1.15.3 → ∅, -49.8 KiB
ruby3.0.6-json-ld: 3.2.3 → ∅, -1090.6 KiB
ruby3.0.6-json-ld-preloaded: 3.2.2 → ∅, -953.3 KiB
ruby3.0.6-json-schema: 3.0.0 → ∅, -152.2 KiB
ruby3.0.6-jsonapi-renderer: 0.2.2 → ∅, -23.4 KiB
ruby3.0.6-jwt: 2.5.0 → ∅, -151.8 KiB
ruby3.0.6-kaminari: 1.2.2 → ∅, -67.6 KiB
ruby3.0.6-kaminari-actionview: 1.2.2 → ∅, -11.9 KiB
ruby3.0.6-kaminari-activerecord: 1.2.2 → ∅, -17.6 KiB
ruby3.0.6-kaminari-core: 1.2.2 → ∅, -62.6 KiB
ruby3.0.6-kt-paperclip: 7.1.1 → ∅, -968.7 KiB
ruby3.0.6-launchy: 2.5.0 → ∅, -101.7 KiB
ruby3.0.6-letter_opener: 1.8.1 → ∅, -51.4 KiB
ruby3.0.6-letter_opener_web: 2.0.0 → ∅, -370.3 KiB
ruby3.0.6-link_header: 0.0.8 → ∅, -21.9 KiB
ruby3.0.6-llhttp-ffi: 0.4.0 → ∅, -640.1 KiB
ruby3.0.6-lograge: 0.12.0 → ∅, -33.9 KiB
ruby3.0.6-loofah: 2.19.1 → ∅, -134.9 KiB
ruby3.0.6-mail: 2.8.1 → ∅, -3731.6 KiB
ruby3.0.6-makara: 0.5.1 → ∅, -206.4 KiB
ruby3.0.6-marcel: 1.0.2 → ∅, -182.3 KiB
ruby3.0.6-mario-redis-lock: 1.2.1 → ∅, -38.5 KiB
ruby3.0.6-matrix: 0.4.2 → ∅, -98.6 KiB
ruby3.0.6-memory_profiler: 1.0.1 → ∅, -58.7 KiB
ruby3.0.6-method_source: 1.0.0 → ∅, -41.6 KiB
ruby3.0.6-mime-types: 3.4.1 → ∅, -130.5 KiB
ruby3.0.6-mime-types-data: 3.2022.0105 → ∅, -1417.1 KiB
ruby3.0.6-mini_mime: 1.1.5 → ∅, -241.1 KiB
ruby3.0.6-mini_portile2: 2.8.4 → ∅, -88.4 KiB
ruby3.0.6-minitest: 5.17.0 → ∅, -334.5 KiB
ruby3.0.6-msgpack: 1.6.0 → ∅, -677.5 KiB
ruby3.0.6-multi_json: 1.15.0 → ∅, -61.6 KiB
ruby3.0.6-multipart-post: 2.1.1 → ∅, -40.2 KiB
ruby3.0.6-net-imap: 0.3.7 → ∅, -316.3 KiB
ruby3.0.6-net-ldap: 0.17.1 → ∅, -215.9 KiB
ruby3.0.6-net-pop: 0.1.2 → ∅, -40.8 KiB
ruby3.0.6-net-protocol: 0.2.1 → ∅, -25.5 KiB
ruby3.0.6-net-scp: 4.0.0.rc1 → ∅, -86.1 KiB
ruby3.0.6-net-smtp: 0.3.3 → ∅, -45.2 KiB
ruby3.0.6-net-ssh: 7.0.1 → ∅, -529.5 KiB
ruby3.0.6-nio4r: 2.5.9 → ∅, -697.6 KiB
ruby3.0.6-nokogiri: 1.14.5 → ∅, -3802.0 KiB
ruby3.0.6-nsa: 0.2.8 → ∅, -30.3 KiB
ruby3.0.6-oj: 3.13.23 → ∅, -2327.4 KiB
ruby3.0.6-omniauth: 1.9.2 → ∅, -59.4 KiB
ruby3.0.6-omniauth-cas: 2.0.0 → ∅, -49.6 KiB
ruby3.0.6-omniauth-rails_csrf_protection: 0.1.2 → ∅, -25.6 KiB
ruby3.0.6-omniauth-saml: 1.10.3 → ∅, -54.3 KiB
ruby3.0.6-openid_connect: 1.4.2 → ∅, -144.5 KiB
ruby3.0.6-openssl: 3.0.0 → ∅, -1853.8 KiB
ruby3.0.6-openssl-signature_algorithm: 1.2.1 → ∅, -47.7 KiB
ruby3.0.6-orm_adapter: 0.5.0 → ∅, -50.8 KiB
ruby3.0.6-ox: 2.14.14 → ∅, -918.5 KiB
ruby3.0.6-parallel: 1.22.1 → ∅, -26.0 KiB
ruby3.0.6-parser: 3.2.0.0 → ∅, -9471.1 KiB
ruby3.0.6-parslet: 2.0.0 → ∅, -297.8 KiB
ruby3.0.6-pastel: 0.8.0 → ∅, -45.6 KiB
ruby3.0.6-pg: 1.4.5 → ∅, -1278.0 KiB
ruby3.0.6-pghero: 3.1.0 → ∅, -1399.6 KiB
ruby3.0.6-pkg-config: 1.5.1 → ∅, -70.5 KiB
ruby3.0.6-posix-spawn: 0.3.15 → ∅, -147.3 KiB
ruby3.0.6-premailer: 1.18.0 → ∅, -89.3 KiB
ruby3.0.6-premailer-rails: 1.12.0 → ∅, -117.8 KiB
ruby3.0.6-private_address_check: 0.5.0 → ∅, -21.0 KiB
ruby3.0.6-pry: 0.14.1 → ∅, -544.3 KiB
ruby3.0.6-pry-byebug: 3.10.1 → ∅, -47.4 KiB
ruby3.0.6-pry-rails: 0.3.9 → ∅, -59.4 KiB
ruby3.0.6-public_suffix: 5.0.1 → ∅, -366.8 KiB
ruby3.0.6-puma: 5.6.7 → ∅, -728.8 KiB
ruby3.0.6-pundit: 2.3.0 → ∅, -107.8 KiB
ruby3.0.6-raabro: 1.4.0 → ∅, -33.8 KiB
ruby3.0.6-racc: 1.6.2 → ∅, -323.4 KiB
ruby3.0.6-rack: 2.2.8 → ∅, -465.2 KiB
ruby3.0.6-rack-attack: 6.6.1 → ∅, -130.5 KiB
ruby3.0.6-rack-cors: 1.1.1 → ∅, -209.9 KiB
ruby3.0.6-rack-oauth2: 1.21.3 → ∅, -202.4 KiB
ruby3.0.6-rack-proxy: 0.7.6 → ∅, -42.7 KiB
ruby3.0.6-rack-test: 2.0.2 → ∅, -60.2 KiB
ruby3.0.6-rails: 6.1.7.6 → ∅, -13.6 KiB
ruby3.0.6-rails-controller-testing: 1.0.5 → ∅, -732.7 KiB
ruby3.0.6-rails-dom-testing: 2.0.3 → ∅, -45.9 KiB
ruby3.0.6-rails-html-sanitizer: 1.5.0 → ∅, -68.1 KiB
ruby3.0.6-rails-i18n: 6.0.0 → ∅, -748.5 KiB
ruby3.0.6-rails-settings-cached: 0.6.6 → ∅, -26.6 KiB
ruby3.0.6-railties: 6.1.7.6 → ∅, -1015.4 KiB
ruby3.0.6-rainbow: 3.1.1 → ∅, -34.7 KiB
ruby3.0.6-rake: 13.0.6 → ∅, -279.9 KiB
ruby3.0.6-rdf: 3.2.9 → ∅, -737.7 KiB
ruby3.0.6-rdf-normalize: 0.5.1 → ∅, -35.8 KiB
ruby3.0.6-redcarpet: 3.6.0 → ∅, -446.5 KiB
ruby3.0.6-redis: 4.5.1 → ∅, -255.3 KiB
ruby3.0.6-redis-namespace: 1.10.0 → ∅, -79.4 KiB
ruby3.0.6-redlock: 1.3.2 → ∅, -62.5 KiB
ruby3.0.6-regexp_parser: 2.6.2 → ∅, -299.3 KiB
ruby3.0.6-request_store: 1.5.1 → ∅, -23.2 KiB
ruby3.0.6-responders: 3.0.1 → ∅, -60.0 KiB
ruby3.0.6-rexml: 3.2.5 → ∅, -417.6 KiB
ruby3.0.6-rotp: 6.2.0 → ∅, -235.3 KiB
ruby3.0.6-rpam2: 4.0.2 → ∅, -58.5 KiB
ruby3.0.6-rqrcode: 2.1.2 → ∅, -153.0 KiB
ruby3.0.6-rqrcode_core: 1.2.0 → ∅, -57.9 KiB
ruby3.0.6-rspec-core: 3.11.0 → ∅, -618.2 KiB
ruby3.0.6-rspec-expectations: 3.11.0 → ∅, -340.1 KiB
ruby3.0.6-rspec-mocks: 3.11.1 → ∅, -307.6 KiB
ruby3.0.6-rspec-rails: 5.1.2 → ∅, -278.1 KiB
ruby3.0.6-rspec-sidekiq: 3.1.0 → ∅, -86.1 KiB
ruby3.0.6-rspec-support: 3.11.1 → ∅, -117.7 KiB
ruby3.0.6-rspec_junit_formatter: 0.6.0 → ∅, -25.9 KiB
ruby3.0.6-rubocop: 1.44.1 → ∅, -2765.3 KiB
ruby3.0.6-rubocop-ast: 1.24.1 → ∅, -251.4 KiB
ruby3.0.6-rubocop-capybara: 2.17.0 → ∅, -49.0 KiB
ruby3.0.6-rubocop-performance: 1.16.0 → ∅, -181.9 KiB
ruby3.0.6-rubocop-rails: 2.17.4 → ∅, -441.0 KiB
ruby3.0.6-rubocop-rspec: 2.18.1 → ∅, -420.4 KiB
ruby3.0.6-ruby-progressbar: 1.11.0 → ∅, -47.0 KiB
ruby3.0.6-ruby-saml: 1.13.0 → ∅, -346.2 KiB
ruby3.0.6-ruby2_keywords: 0.0.5 → ∅, -27.4 KiB
ruby3.0.6-rufus-scheduler: 3.8.2 → ∅, -121.2 KiB
ruby3.0.6-safety_net_attestation: 0.4.0 → ∅, -37.6 KiB
ruby3.0.6-sanitize: 6.0.2 → ∅, -190.8 KiB
ruby3.0.6-scenic: 1.7.0 → ∅, -152.6 KiB
ruby3.0.6-semantic_range: 3.0.0 → ∅, -34.6 KiB
ruby3.0.6-sidekiq: 6.5.11 → ∅, -1113.4 KiB
ruby3.0.6-sidekiq-bulk: 0.2.0 → ∅, -28.8 KiB
ruby3.0.6-sidekiq-scheduler: 4.0.3 → ∅, -79.0 KiB
ruby3.0.6-sidekiq-unique-jobs: 7.1.29 → ∅, -417.8 KiB
ruby3.0.6-simple-navigation: 4.4.0 → ∅, -212.2 KiB
ruby3.0.6-simple_form: 5.2.0 → ∅, -461.2 KiB
ruby3.0.6-simplecov: 0.22.0 → ∅, -157.3 KiB
ruby3.0.6-simplecov-html: 0.12.3 → ∅, -1145.6 KiB
ruby3.0.6-simplecov_json_formatter: 0.1.4 → ∅, -12.7 KiB
ruby3.0.6-smart_properties: 1.17.0 → ∅, -91.4 KiB
ruby3.0.6-sprockets: 3.7.2 → ∅, -268.4 KiB
ruby3.0.6-sprockets-rails: 3.4.2 → ∅, -47.6 KiB
ruby3.0.6-sshkit: 1.21.2 → ∅, -309.3 KiB
ruby3.0.6-stackprof: 0.2.23 → ∅, -348.8 KiB
ruby3.0.6-statsd-ruby: 1.5.0 → ∅, -51.4 KiB
ruby3.0.6-stoplight: 3.0.1 → ∅, -105.9 KiB
ruby3.0.6-strong_migrations: 0.7.9 → ∅, -77.7 KiB
ruby3.0.6-swd: 1.3.0 → ∅, -34.1 KiB
ruby3.0.6-temple: 0.8.2 → ∅, -157.9 KiB
ruby3.0.6-terminal-table: 3.0.2 → ∅, -68.6 KiB
ruby3.0.6-terrapin: 0.6.0 → ∅, -58.4 KiB
ruby3.0.6-thor: 1.2.2 → ∅, -192.6 KiB
ruby3.0.6-tilt: 2.0.11 → ∅, -77.7 KiB
ruby3.0.6-timeout: 0.3.2 → ∅, -15.8 KiB
ruby3.0.6-tpm-key_attestation: 0.11.0 → ∅, -82.0 KiB
ruby3.0.6-tty-color: 0.6.0 → ∅, -22.0 KiB
ruby3.0.6-tty-cursor: 0.7.1 → ∅, -22.3 KiB
ruby3.0.6-tty-prompt: 0.23.1 → ∅, -204.6 KiB
ruby3.0.6-tty-reader: 0.9.0 → ∅, -59.8 KiB
ruby3.0.6-tty-screen: 0.8.1 → ∅, -25.2 KiB
ruby3.0.6-twitter-text: 3.1.0 → ∅, -249.7 KiB
ruby3.0.6-tzinfo: 2.0.6 → ∅, -349.9 KiB
ruby3.0.6-tzinfo-data: 1.2022.7 → ∅, -2294.7 KiB
ruby3.0.6-unf: 0.1.4 → ∅, -576.7 KiB
ruby3.0.6-unf_ext: 0.0.8.2 → ∅, -2859.0 KiB
ruby3.0.6-unicode-display_width: 2.4.2 → ∅, -26.8 KiB
ruby3.0.6-uniform_notifier: 1.16.0 → ∅, -59.2 KiB
ruby3.0.6-validate_email: 0.1.6 → ∅, -10.2 KiB
ruby3.0.6-validate_url: 1.0.15 → ∅, -20.1 KiB
ruby3.0.6-warden: 1.2.9 → ∅, -64.2 KiB
ruby3.0.6-webauthn: 2.5.2 → ∅, -153.3 KiB
ruby3.0.6-webfinger: 1.2.0 → ∅, -33.0 KiB
ruby3.0.6-webmock: 3.18.1 → ∅, -665.0 KiB
ruby3.0.6-webpacker: 5.4.4 → ∅, -716.0 KiB
ruby3.0.6-webpush: 0.3.8 → ∅, -138.5 KiB
ruby3.0.6-websocket-driver: 0.7.6 → ∅, -103.8 KiB
ruby3.0.6-websocket-extensions: 0.1.5 → ∅, -27.2 KiB
ruby3.0.6-wisper: 2.0.1 → ∅, -82.5 KiB
ruby3.0.6-xorcist: 1.1.3 → ∅, -44.4 KiB
ruby3.0.6-xpath: 3.2.0 → ∅, -55.7 KiB
ruby3.0.6-zeitwerk: 2.6.12 → ∅, -129.5 KiB
ruby3.2.2-actioncable: ∅ → 7.0.8, +192.8 KiB
ruby3.2.2-actionmailbox: ∅ → 7.0.8, +86.5 KiB
ruby3.2.2-actionmailer: ∅ → 7.0.8, +105.4 KiB
ruby3.2.2-actionpack: ∅ → 7.0.8, +886.9 KiB
ruby3.2.2-actiontext: ∅ → 7.0.8, +447.4 KiB
ruby3.2.2-actionview: ∅ → 7.0.8, +776.9 KiB
ruby3.2.2-active_model_serializers: ∅ → 0.10.13, +247.5 KiB
ruby3.2.2-activejob: ∅ → 7.0.8, +135.3 KiB
ruby3.2.2-activemodel: ∅ → 7.0.8, +264.2 KiB
ruby3.2.2-activerecord: ∅ → 7.0.8, +2067.4 KiB
ruby3.2.2-activestorage: ∅ → 7.0.8, +286.1 KiB
ruby3.2.2-activesupport: ∅ → 7.0.8, +909.4 KiB
ruby3.2.2-addressable: ∅ → 2.8.5, +540.6 KiB
ruby3.2.2-aes_key_wrap: ∅ → 1.1.0, +17.8 KiB
ruby3.2.2-airbrussh: ∅ → 1.4.1, +58.1 KiB
ruby3.2.2-android_key_attestation: ∅ → 0.3.0, +34.5 KiB
ruby3.2.2-annotate: ∅ → 3.2.0, +131.9 KiB
ruby3.2.2-ast: ∅ → 2.4.2, +28.6 KiB
ruby3.2.2-attr_encrypted: ∅ → 4.0.0, +130.7 KiB
ruby3.2.2-attr_required: ∅ → 1.0.1, +22.4 KiB
ruby3.2.2-awrence: ∅ → 1.2.1, +14.9 KiB
ruby3.2.2-aws-eventstream: ∅ → 1.2.0, +34.7 KiB
ruby3.2.2-aws-partitions: ∅ → 1.809.0, +931.0 KiB
ruby3.2.2-aws-sdk-core: ∅ → 3.181.0, +1281.7 KiB
ruby3.2.2-aws-sdk-kms: ∅ → 1.71.0, +940.0 KiB
ruby3.2.2-aws-sdk-s3: ∅ → 1.133.0, +2448.9 KiB
ruby3.2.2-aws-sigv4: ∅ → 1.6.0, +57.7 KiB
ruby3.2.2-azure-storage-blob: ∅ → 2.0.3, +267.1 KiB
ruby3.2.2-azure-storage-common: ∅ → 2.0.4, +262.2 KiB
ruby3.2.2-base64: ∅ → 0.1.1, +12.0 KiB
ruby3.2.2-bcp47_spec: ∅ → 0.2.1, +13.6 KiB
ruby3.2.2-bcrypt: ∅ → 3.1.18, +226.2 KiB
ruby3.2.2-better_errors: ∅ → 2.10.1, +116.6 KiB
ruby3.2.2-better_html: ∅ → 2.0.1, +209.5 KiB
ruby3.2.2-bindata: ∅ → 2.4.15, +343.0 KiB
ruby3.2.2-binding_of_caller: ∅ → 1.0.0, +25.4 KiB
ruby3.2.2-blurhash: ∅ → 0.1.7, +59.2 KiB
ruby3.2.2-bootsnap: ∅ → 1.16.0, +189.4 KiB
ruby3.2.2-brakeman: ∅ → 6.0.1, +10236.3 KiB
ruby3.2.2-browser: ∅ → 5.3.1, +252.0 KiB
ruby3.2.2-brpoplpush-redis_script: ∅ → 0.1.3, +38.8 KiB
ruby3.2.2-builder: ∅ → 3.2.4, +108.0 KiB
ruby3.2.2-bundler-audit: ∅ → 0.9.1, +218.7 KiB
ruby3.2.2-capistrano: ∅ → 3.17.3, +299.9 KiB
ruby3.2.2-capistrano-bundler: ∅ → 2.1.0, +23.0 KiB
ruby3.2.2-capistrano-rails: ∅ → 1.6.3, +25.9 KiB
ruby3.2.2-capistrano-rbenv: ∅ → 2.2.0, +16.3 KiB
ruby3.2.2-capistrano-yarn: ∅ → 2.0.2, +14.8 KiB
ruby3.2.2-capybara: ∅ → 3.39.2, +1730.4 KiB
ruby3.2.2-case_transform: ∅ → 0.2, +11.9 KiB
ruby3.2.2-cbor: ∅ → 0.5.9.6, +428.9 KiB
ruby3.2.2-charlock_holmes: ∅ → 0.7.7, +97.0 KiB
ruby3.2.2-chewy: ∅ → 7.3.4, +886.3 KiB
ruby3.2.2-chunky_png: ∅ → 1.4.0, +1255.5 KiB
ruby3.2.2-climate_control: ∅ → 0.2.0, +21.7 KiB
ruby3.2.2-cocoon: ∅ → 1.2.15, +385.8 KiB
ruby3.2.2-color_diff: ∅ → 0.1, +16.8 KiB
ruby3.2.2-concurrent-ruby: ∅ → 1.2.2, +1173.5 KiB
ruby3.2.2-connection_pool: ∅ → 2.4.1, +27.5 KiB
ruby3.2.2-cose: ∅ → 1.3.0, +61.9 KiB
ruby3.2.2-crack: ∅ → 0.4.5, +18.3 KiB
ruby3.2.2-crass: ∅ → 1.0.6, +61.3 KiB
ruby3.2.2-css_parser: ∅ → 1.14.0, +65.4 KiB
ruby3.2.2-database_cleaner-active_record: ∅ → 2.1.0, +41.3 KiB
ruby3.2.2-database_cleaner-core: ∅ → 2.0.1, +68.0 KiB
ruby3.2.2-date: ∅ → 3.3.3, +930.1 KiB
ruby3.2.2-debug_inspector: ∅ → 1.1.0, +55.5 KiB
ruby3.2.2-devise: ∅ → 4.9.2, +357.3 KiB
ruby3.2.2-devise-two-factor: ∅ → 4.1.0, +75.1 KiB
ruby3.2.2-devise_pam_authenticatable2: ∅ → 9.2.0, +20.9 KiB
ruby3.2.2-diff-lcs: ∅ → 1.5.0, +202.4 KiB
ruby3.2.2-discard: ∅ → 1.2.1, +36.4 KiB
ruby3.2.2-docile: ∅ → 1.4.0, +43.4 KiB
ruby3.2.2-domain_name: ∅ → 0.5.20190701, +480.8 KiB
ruby3.2.2-doorkeeper: ∅ → 5.6.6, +487.8 KiB
ruby3.2.2-dotenv: ∅ → 2.8.1, +32.0 KiB
ruby3.2.2-dotenv-rails: ∅ → 2.8.1, +21.3 KiB
ruby3.2.2-ed25519: ∅ → 1.3.0, +679.0 KiB
ruby3.2.2-elasticsearch: ∅ → 7.13.3, +47.9 KiB
ruby3.2.2-elasticsearch-api: ∅ → 7.13.3, +893.5 KiB
ruby3.2.2-elasticsearch-dsl: ∅ → 0.1.10, +697.2 KiB
ruby3.2.2-elasticsearch-transport: ∅ → 7.13.3, +306.5 KiB
ruby3.2.2-encryptor: ∅ → 3.0.0, +54.0 KiB
ruby3.2.2-erubi: ∅ → 1.12.0, +29.4 KiB
ruby3.2.2-et-orbi: ∅ → 1.2.7, +49.2 KiB
ruby3.2.2-excon: ∅ → 0.100.0, +351.7 KiB
ruby3.2.2-fabrication: ∅ → 2.30.0, +54.0 KiB
ruby3.2.2-faker: ∅ → 3.2.1, +6743.9 KiB
ruby3.2.2-faraday: ∅ → 1.10.3, +310.0 KiB
ruby3.2.2-faraday-em_http: ∅ → 1.0.0, +21.0 KiB
ruby3.2.2-faraday-em_synchrony: ∅ → 1.0.0, +18.1 KiB
ruby3.2.2-faraday-excon: ∅ → 1.1.0, +14.4 KiB
ruby3.2.2-faraday-httpclient: ∅ → 1.0.1, +15.9 KiB
ruby3.2.2-faraday-multipart: ∅ → 1.0.4, +25.6 KiB
ruby3.2.2-faraday-net_http: ∅ → 1.0.1, +17.7 KiB
ruby3.2.2-faraday-net_http_persistent: ∅ → 1.2.0, +15.6 KiB
ruby3.2.2-faraday-patron: ∅ → 1.0.0, +15.0 KiB
ruby3.2.2-faraday-rack: ∅ → 1.0.0, +13.1 KiB
ruby3.2.2-faraday-retry: ∅ → 1.0.3, +23.0 KiB
ruby3.2.2-faraday_middleware: ∅ → 1.2.0, +51.3 KiB
ruby3.2.2-fast_blank: ∅ → 1.0.1, +54.6 KiB
ruby3.2.2-fastimage: ∅ → 2.2.7, +44.6 KiB
ruby3.2.2-ffi: ∅ → 1.15.5, +4900.1 KiB
ruby3.2.2-ffi-compiler: ∅ → 1.0.1, +40.6 KiB
ruby3.2.2-fog-core: ∅ → 2.1.0, +232.3 KiB
ruby3.2.2-fog-json: ∅ → 1.2.0, +18.6 KiB
ruby3.2.2-fog-openstack: ∅ → 0.3.10, +1542.6 KiB
ruby3.2.2-formatador: ∅ → 0.3.0, +34.5 KiB
ruby3.2.2-fugit: ∅ → 1.8.1, +89.1 KiB
ruby3.2.2-fuubar: ∅ → 2.5.1, +21.4 KiB
ruby3.2.2-globalid: ∅ → 1.1.0, +36.8 KiB
ruby3.2.2-haml: ∅ → 6.1.2, +319.9 KiB
ruby3.2.2-haml-rails: ∅ → 2.1.0, +43.2 KiB
ruby3.2.2-haml_lint: ∅ → 0.50.0, +278.1 KiB
ruby3.2.2-hashdiff: ∅ → 1.0.1, +79.0 KiB
ruby3.2.2-hashie: ∅ → 5.0.0, +198.9 KiB
ruby3.2.2-hcaptcha: ∅ → 7.1.0, +30.5 KiB
ruby3.2.2-highline: ∅ → 2.1.0, +370.6 KiB
ruby3.2.2-hiredis: ∅ → 0.6.3, +640.9 KiB
ruby3.2.2-hkdf: ∅ → 0.3.0, +18.4 KiB
ruby3.2.2-htmlentities: ∅ → 4.3.4, +132.9 KiB
ruby3.2.2-http: ∅ → 5.1.1, +317.8 KiB
ruby3.2.2-http-cookie: ∅ → 1.0.5, +164.3 KiB
ruby3.2.2-http-form_data: ∅ → 2.3.0, +59.6 KiB
ruby3.2.2-http_accept_language: ∅ → 2.1.1, +30.7 KiB
ruby3.2.2-httpclient: ∅ → 2.8.3, +911.6 KiB
ruby3.2.2-httplog: ∅ → 1.6.2, +50.6 KiB
ruby3.2.2-i18n: ∅ → 1.14.1, +177.2 KiB
ruby3.2.2-i18n-tasks: ∅ → 1.0.12, +260.6 KiB
ruby3.2.2-idn-ruby: ∅ → 0.1.5, +109.5 KiB
ruby3.2.2-ipaddress: ∅ → 0.8.3, +148.2 KiB
ruby3.2.2-jmespath: ∅ → 1.6.2, +88.1 KiB
ruby3.2.2-json: ∅ → 2.6.3, +455.3 KiB
ruby3.2.2-json-canonicalization: ∅ → 1.0.0, +23.0 KiB
ruby3.2.2-json-jwt: ∅ → 1.15.3, +49.8 KiB
ruby3.2.2-json-ld: ∅ → 3.3.1, +410.4 KiB
ruby3.2.2-json-ld-preloaded: ∅ → 3.2.2, +953.3 KiB
ruby3.2.2-json-schema: ∅ → 4.0.0, +154.0 KiB
ruby3.2.2-jsonapi-renderer: ∅ → 0.2.2, +23.4 KiB
ruby3.2.2-jwt: ∅ → 2.7.1, +164.1 KiB
ruby3.2.2-kaminari: ∅ → 1.2.2, +67.6 KiB
ruby3.2.2-kaminari-actionview: ∅ → 1.2.2, +11.9 KiB
ruby3.2.2-kaminari-activerecord: ∅ → 1.2.2, +17.6 KiB
ruby3.2.2-kaminari-core: ∅ → 1.2.2, +62.6 KiB
ruby3.2.2-kt-paperclip: ∅ → 7.2.1, +974.5 KiB
ruby3.2.2-language_server-protocol: ∅ → 3.17.0.3, +577.2 KiB
ruby3.2.2-launchy: ∅ → 2.5.2, +101.9 KiB
ruby3.2.2-letter_opener: ∅ → 1.8.1, +51.4 KiB
ruby3.2.2-letter_opener_web: ∅ → 2.0.0, +370.4 KiB
ruby3.2.2-link_header: ∅ → 0.0.8, +21.9 KiB
ruby3.2.2-llhttp-ffi: ∅ → 0.4.0, +640.1 KiB
ruby3.2.2-lograge: ∅ → 0.13.0, +35.8 KiB
ruby3.2.2-loofah: ∅ → 2.21.3, +113.3 KiB
ruby3.2.2-mail: ∅ → 2.8.1, +3731.7 KiB
ruby3.2.2-marcel: ∅ → 1.0.2, +182.4 KiB
ruby3.2.2-mario-redis-lock: ∅ → 1.2.1, +38.6 KiB
ruby3.2.2-matrix: ∅ → 0.4.2, +98.6 KiB
ruby3.2.2-md-paperclip-azure: ∅ → 2.2.0, +31.3 KiB
ruby3.2.2-memory_profiler: ∅ → 1.0.1, +58.7 KiB
ruby3.2.2-method_source: ∅ → 1.0.0, +41.7 KiB
ruby3.2.2-mime-types: ∅ → 3.5.1, +133.7 KiB
ruby3.2.2-mime-types-data: ∅ → 3.2023.0808, +1477.6 KiB
ruby3.2.2-mini_mime: ∅ → 1.1.5, +241.1 KiB
ruby3.2.2-mini_portile2: ∅ → 2.8.4, +88.4 KiB
ruby3.2.2-minitest: ∅ → 5.19.0, +342.4 KiB
ruby3.2.2-msgpack: ∅ → 1.7.1, +499.5 KiB
ruby3.2.2-multi_json: ∅ → 1.15.0, +61.7 KiB
ruby3.2.2-multipart-post: ∅ → 2.3.0, +34.0 KiB
ruby3.2.2-net-http: ∅ → 0.3.2, +183.5 KiB
ruby3.2.2-net-http-persistent: ∅ → 4.0.2, +95.3 KiB
ruby3.2.2-net-imap: ∅ → 0.3.7, +316.3 KiB
ruby3.2.2-net-ldap: ∅ → 0.18.0, +216.1 KiB
ruby3.2.2-net-pop: ∅ → 0.1.2, +40.8 KiB
ruby3.2.2-net-protocol: ∅ → 0.2.1, +25.5 KiB
ruby3.2.2-net-scp: ∅ → 4.0.0, +86.1 KiB
ruby3.2.2-net-smtp: ∅ → 0.3.3, +45.2 KiB
ruby3.2.2-net-ssh: ∅ → 7.1.0, +533.4 KiB
ruby3.2.2-nio4r: ∅ → 2.5.9, +689.3 KiB
ruby3.2.2-nokogiri: ∅ → 1.15.4, +3767.1 KiB
ruby3.2.2-nsa-e020fcc3a54d: ∅ → ε, +99.0 KiB
ruby3.2.2-oj: ∅ → 3.16.1, +2249.9 KiB
ruby3.2.2-omniauth: ∅ → 2.1.1, +69.1 KiB
ruby3.2.2-omniauth-cas: ∅ → 4211e6d05941, +107.3 KiB
ruby3.2.2-omniauth-rails_csrf_protection: ∅ → 1.0.1, +27.9 KiB
ruby3.2.2-omniauth-saml: ∅ → 2.1.0, +54.9 KiB
ruby3.2.2-omniauth_openid_connect: ∅ → 0.6.1, +95.9 KiB
ruby3.2.2-openid_connect: ∅ → 1.4.2, +144.6 KiB
ruby3.2.2-openssl: ∅ → 3.1.0, +1860.6 KiB
ruby3.2.2-openssl-signature_algorithm: ∅ → 1.3.0, +49.1 KiB
ruby3.2.2-orm_adapter: ∅ → 0.5.0, +50.9 KiB
ruby3.2.2-ox: ∅ → 2.14.17, +932.2 KiB
ruby3.2.2-parallel: ∅ → 1.23.0, +25.7 KiB
ruby3.2.2-parser: ∅ → 3.2.2.3, +9868.0 KiB
ruby3.2.2-parslet: ∅ → 2.0.0, +297.8 KiB
ruby3.2.2-pastel: ∅ → 0.8.0, +45.6 KiB
ruby3.2.2-pg: ∅ → 1.5.4, +1444.7 KiB
ruby3.2.2-pghero: ∅ → 3.3.4, +1666.7 KiB
ruby3.2.2-posix-spawn: ∅ → 0.3.15, +147.4 KiB
ruby3.2.2-premailer: ∅ → 1.21.0, +88.8 KiB
ruby3.2.2-premailer-rails: ∅ → 1.12.0, +117.9 KiB
ruby3.2.2-private_address_check: ∅ → 0.5.0, +21.0 KiB
ruby3.2.2-public_suffix: ∅ → 5.0.3, +361.7 KiB
ruby3.2.2-puma: ∅ → 6.3.1, +792.5 KiB
ruby3.2.2-pundit: ∅ → 2.3.0, +107.9 KiB
ruby3.2.2-raabro: ∅ → 1.4.0, +33.8 KiB
ruby3.2.2-racc: ∅ → 1.7.1, +323.9 KiB
ruby3.2.2-rack: ∅ → 2.2.8, +465.2 KiB
ruby3.2.2-rack-attack: ∅ → 6.7.0, +132.1 KiB
ruby3.2.2-rack-cors: ∅ → 2.0.1, +215.7 KiB
ruby3.2.2-rack-oauth2: ∅ → 1.21.3, +202.5 KiB
ruby3.2.2-rack-protection: ∅ → 3.0.5, +66.1 KiB
ruby3.2.2-rack-proxy: ∅ → 0.7.6, +42.7 KiB
ruby3.2.2-rack-test: ∅ → 2.1.0, +59.0 KiB
ruby3.2.2-rails: ∅ → 7.0.8, +14.6 KiB
ruby3.2.2-rails-controller-testing: ∅ → 1.0.5, +732.8 KiB
ruby3.2.2-rails-dom-testing: ∅ → 2.1.1, +50.1 KiB
ruby3.2.2-rails-html-sanitizer: ∅ → 1.6.0, +95.2 KiB
ruby3.2.2-rails-i18n: ∅ → 7.0.7, +815.4 KiB
ruby3.2.2-rails-settings-cached: ∅ → 86328ef0bd04, +116.1 KiB
ruby3.2.2-railties: ∅ → 7.0.8, +632.2 KiB
ruby3.2.2-rainbow: ∅ → 3.1.1, +34.7 KiB
ruby3.2.2-rake: ∅ → 13.0.6, +279.9 KiB
ruby3.2.2-rdf: ∅ → 3.3.1, +743.7 KiB
ruby3.2.2-rdf-normalize: ∅ → 0.6.1, +44.2 KiB
ruby3.2.2-redcarpet: ∅ → 3.6.0, +446.5 KiB
ruby3.2.2-redis: ∅ → 4.8.1, +289.6 KiB
ruby3.2.2-redis-namespace: ∅ → 1.11.0, +80.3 KiB
ruby3.2.2-redlock: ∅ → 1.3.2, +62.5 KiB
ruby3.2.2-regexp_parser: ∅ → 2.8.1, +291.9 KiB
ruby3.2.2-request_store: ∅ → 1.5.1, +23.3 KiB
ruby3.2.2-responders: ∅ → 3.1.0, +63.5 KiB
ruby3.2.2-rexml: ∅ → 3.2.6, +462.0 KiB
ruby3.2.2-rotp: ∅ → 6.2.2, +67.0 KiB
ruby3.2.2-rouge: ∅ → 4.1.2, +1963.4 KiB
ruby3.2.2-rpam2: ∅ → 4.0.2, +58.5 KiB
ruby3.2.2-rqrcode: ∅ → 2.2.0, +153.7 KiB
ruby3.2.2-rqrcode_core: ∅ → 1.2.0, +58.0 KiB
ruby3.2.2-rspec-core: ∅ → 3.12.2, +618.9 KiB
ruby3.2.2-rspec-expectations: ∅ → 3.12.3, +342.6 KiB
ruby3.2.2-rspec-mocks: ∅ → 3.12.5, +313.1 KiB
ruby3.2.2-rspec-rails: ∅ → 6.0.3, +282.2 KiB
ruby3.2.2-rspec-sidekiq: ∅ → 4.0.1, +54.1 KiB
ruby3.2.2-rspec-support: ∅ → 3.12.1, +118.6 KiB
ruby3.2.2-rspec_chunked: ∅ → 0.6, +15.0 KiB
ruby3.2.2-rubocop: ∅ → 1.56.3, +2902.6 KiB
ruby3.2.2-rubocop-ast: ∅ → 1.29.0, +252.6 KiB
ruby3.2.2-rubocop-capybara: ∅ → 2.18.0, +53.3 KiB
ruby3.2.2-rubocop-factory_bot: ∅ → 2.23.1, +64.8 KiB
ruby3.2.2-rubocop-performance: ∅ → 1.19.0, +187.7 KiB
ruby3.2.2-rubocop-rails: ∅ → 2.20.2, +456.7 KiB
ruby3.2.2-rubocop-rspec: ∅ → 2.23.2, +441.3 KiB
ruby3.2.2-ruby-prof: ∅ → 1.6.3, +747.3 KiB
ruby3.2.2-ruby-progressbar: ∅ → 1.13.0, +50.0 KiB
ruby3.2.2-ruby-saml: ∅ → 1.15.0, +350.6 KiB
ruby3.2.2-ruby2_keywords: ∅ → 0.0.5, +27.4 KiB
ruby3.2.2-rubyzip: ∅ → 2.3.2, +150.8 KiB
ruby3.2.2-rufus-scheduler: ∅ → 3.9.1, +124.0 KiB
ruby3.2.2-safety_net_attestation: ∅ → 0.4.0, +37.6 KiB
ruby3.2.2-sanitize: ∅ → 6.0.2, +190.8 KiB
ruby3.2.2-scenic: ∅ → 1.7.0, +152.7 KiB
ruby3.2.2-selenium-webdriver: ∅ → 4.11.0, +13085.2 KiB
ruby3.2.2-semantic_range: ∅ → 3.0.0, +34.6 KiB
ruby3.2.2-sidekiq: ∅ → 6.5.10, +1114.1 KiB
ruby3.2.2-sidekiq-bulk: ∅ → 0.2.0, +28.9 KiB
ruby3.2.2-sidekiq-scheduler: ∅ → 5.0.3, +88.5 KiB
ruby3.2.2-sidekiq-unique-jobs: ∅ → 7.1.29, +417.8 KiB
ruby3.2.2-simple-navigation: ∅ → 4.4.0, +212.3 KiB
ruby3.2.2-simple_form: ∅ → 5.2.0, +461.2 KiB
ruby3.2.2-simplecov: ∅ → 0.22.0, +157.3 KiB
ruby3.2.2-simplecov-html: ∅ → 0.12.3, +1145.6 KiB
ruby3.2.2-simplecov_json_formatter: ∅ → 0.1.4, +12.7 KiB
ruby3.2.2-smart_properties: ∅ → 1.17.0, +91.5 KiB
ruby3.2.2-sprockets: ∅ → 3.7.2, +268.5 KiB
ruby3.2.2-sprockets-rails: ∅ → 3.4.2, +47.6 KiB
ruby3.2.2-sshkit: ∅ → 1.21.5, +312.5 KiB
ruby3.2.2-stackprof: ∅ → 0.2.25, +349.7 KiB
ruby3.2.2-statsd-ruby: ∅ → 1.5.0, +51.5 KiB
ruby3.2.2-stoplight: ∅ → 3.0.2, +106.8 KiB
ruby3.2.2-strong_migrations: ∅ → 0.8.0, +76.3 KiB
ruby3.2.2-swd: ∅ → 1.3.0, +34.1 KiB
ruby3.2.2-sysexits: ∅ → 1.2.0, +31.2 KiB
ruby3.2.2-temple: ∅ → 0.10.2, +164.8 KiB
ruby3.2.2-terminal-table: ∅ → 3.0.2, +68.7 KiB
ruby3.2.2-terrapin: ∅ → 0.6.0, +58.5 KiB
ruby3.2.2-test-prof: ∅ → 1.2.3, +948.4 KiB
ruby3.2.2-thor: ∅ → 1.2.2, +192.6 KiB
ruby3.2.2-tilt: ∅ → 2.2.0, +86.7 KiB
ruby3.2.2-timeout: ∅ → 0.4.0, +15.7 KiB
ruby3.2.2-tpm-key_attestation: ∅ → 0.12.0, +82.9 KiB
ruby3.2.2-tty-color: ∅ → 0.6.0, +22.0 KiB
ruby3.2.2-tty-cursor: ∅ → 0.7.1, +22.3 KiB
ruby3.2.2-tty-prompt: ∅ → 0.23.1, +204.6 KiB
ruby3.2.2-tty-reader: ∅ → 0.9.0, +59.9 KiB
ruby3.2.2-tty-screen: ∅ → 0.8.1, +25.2 KiB
ruby3.2.2-twitter-text: ∅ → 3.1.0, +249.8 KiB
ruby3.2.2-tzinfo: ∅ → 2.0.6, +349.9 KiB
ruby3.2.2-tzinfo-data: ∅ → 1.2023.3, +2313.3 KiB
ruby3.2.2-unf: ∅ → 0.1.4, +576.8 KiB
ruby3.2.2-unf_ext: ∅ → 0.0.8.2, +2859.1 KiB
ruby3.2.2-unicode-display_width: ∅ → 2.4.2, +26.8 KiB
ruby3.2.2-uri: ∅ → 0.12.2, +129.7 KiB
ruby3.2.2-validate_email: ∅ → 0.1.6, +10.2 KiB
ruby3.2.2-validate_url: ∅ → 1.0.15, +20.2 KiB
ruby3.2.2-warden: ∅ → 1.2.9, +64.2 KiB
ruby3.2.2-webauthn: ∅ → 3.0.0, +161.4 KiB
ruby3.2.2-webfinger: ∅ → 1.2.0, +33.0 KiB
ruby3.2.2-webmock: ∅ → 3.19.1, +269.3 KiB
ruby3.2.2-webpacker: ∅ → 5.4.4, +716.1 KiB
ruby3.2.2-webpush-f14a4d52e201: ∅ → ε, +138.5 KiB
ruby3.2.2-websocket: ∅ → 1.2.9, +142.9 KiB
ruby3.2.2-websocket-driver: ∅ → 0.7.6, +103.7 KiB
ruby3.2.2-websocket-extensions: ∅ → 0.1.5, +27.2 KiB
ruby3.2.2-wisper: ∅ → 2.0.1, +82.5 KiB
ruby3.2.2-xorcist: ∅ → 1.1.3, +44.4 KiB
ruby3.2.2-xpath: ∅ → 3.2.0, +55.7 KiB
ruby3.2.2-zeitwerk: ∅ → 2.6.11, +129.2 KiB
s2n-tls: 1.3.43 → 1.3.56, +109.5 KiB
sbc: 1.4 → 2.0, +25.8 KiB
sd: 0.7.6 → 1.0.0, +792.1 KiB
security: ε → ∅, -17.1 KiB
security-wrapper-x86_64-unknown-linux: ∅ → ε, +942.9 KiB
serd: -37.8 KiB
shadow: 4.13 → 4.14.1, +167.1 KiB
shared-mime-info: 2.2 → 2.3, +148.3 KiB
sops-install-secrets: +381.2 KiB
sord: -375.0 KiB
source: -350.3 KiB
soxr: -18.3 KiB
sqlite: 3.41.2 → 3.43.2, +33.9 KiB
srt: 1.5.1 → 1.5.2, +103.1 KiB
stage: ∅ → 1-init.sh, +20.3 KiB
statsd_exporter: 0.23.1 → 0.25.0, +479.7 KiB
sudo: 1.9.13p3 → 1.9.15p2, +390.2 KiB
svt-av1: ∅ → 1.7.0, +10625.5 KiB
system: +109.8 KiB
systemd: 253.6 → 254.6, +1762.3 KiB
systemd-minimal: 253.6 → 254.6, +741.6 KiB
systemd-minimal-libs: ∅ → 254.6, +1507.4 KiB
tpm2-tss: 3.2.0 → 4.0.1, +817.8 KiB
udev: +40.3 KiB
unbound: 1.17.1 → 1.18.0, +8.5 KiB
unit-acme-lockfiles.service: ∅ → ε
unit-domainname.service: ∅ → ε
unit-graphical-session.target: ε → ∅
unit-mastodon-streaming: ∅ → 1.service, 2.service, 3.service, +11.7 KiB
unit-mastodon-streaming.service: ε → ∅
unit-mastodon-streaming.target: ∅ → ε
unit-nix-optimise.timer: ∅ → ε
unit-nixos-fake-graphical-session.target: ∅ → ε
unit-script-acme-lockfiles: ∅ → ε
unit-script-suid-sgid-wrappers: ∅ → ε
unit-script-systemd-timesyncd-pre: ∅ → ε
unit-suid-sgid-wrappers.service: ∅ → ε
unit-systemd-makefs: ∅ → .service
unit-systemd-mkswap: ∅ → .service
utf8proc: 2.8.0 → 2.9.0
util-linux: 2.38.1 → 2.39.2, +2261.9 KiB
util-linux-minimal: 2.38.1 → 2.39.2, +828.6 KiB
v4l-utils: 1.22.1 → 1.24.1
vim: 9.0.1441 → 9.0.2048, +860.2 KiB
vulkan-loader: 1.3.249 → 1.3.268.0, +17.9 KiB
wavpack: 5.5.0 → 5.6.0
webrtc-audio-processing: 0.3.1 → 1.3, +593.7 KiB
wrapped-ruby-mastodon-cuties-socal-gems: 4.1.10 → 4.2.3, +15.6 KiB
x265: -15.5 KiB
xcb-util: 0.4.1 → ∅, -46.4 KiB
xgcc: 12.2.0 → 12.3.0
xkeyboard-config: 2.33 → 2.40, +892.2 KiB
xorgproto: 2021.5 → 2023.2, +9.2 KiB
xxHash: 0.8.1 → 0.8.2, +38.6 KiB
xz: 5.4.3 → 5.4.4, +29.3 KiB
zimg: 3.0.4 → 3.0.5, -137.1 KiB
zlib: 1.2.13 → 1.3
zlib-ng: 2.0.7 → 2.1.4, +33.4 KiB
```