### PR TITLE
set uploadsize to 100m

### DIFF
--- a/configuration.nix
+++ b/configuration.nix
@@ -408,6 +408,8 @@ in
 
   systemd.services.restic-backup-mastodon.serviceConfig.SupplementaryGroups = config.systemd.services.redis-mastodon.serviceConfig.Group;
 
+  services.nginx.clientMaxBodySize = "100m";
+
   services.journald.extraConfig = "SystemMaxUse=512M";
   services.logrotate.settings.nginx = {
     frequency = "daily";


### PR DESCRIPTION
mastodon 4.2 can process videos up to 99MB out of the box, but our reverse proxy must also be able to pass it to it.