### PR TITLE
mastodon 4.2.4 -> 4.2.5

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -18,11 +18,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1705183652,
-        "narHash": "sha256-rnfkyUH0x72oHfiSDhuCHDHg3gFgF+lF8zkkg5Zihsw=",
+        "lastModified": 1706515015,
+        "narHash": "sha256-eFfY5A7wlYy3jD/75lx6IJRueg4noE+jowl0a8lIlVo=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "428544ae95eec077c7f823b422afae5f174dee4b",
+        "rev": "f4a8d6d5324c327dcc2d863eb7f3cc06ad630df4",
         "type": "github"
       },
       "original": {
@@ -34,11 +34,11 @@
     },
     "nixpkgs-stable": {
       "locked": {
-        "lastModified": 1705033721,
-        "narHash": "sha256-K5eJHmL1/kev6WuqyqqbS1cdNnSidIZ3jeqJ7GbrYnQ=",
+        "lastModified": 1705957679,
+        "narHash": "sha256-Q8LJaVZGJ9wo33wBafvZSzapYsjOaNjP/pOnSiKVGHY=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "a1982c92d8980a0114372973cbdfe0a307f1bdea",
+        "rev": "9a333eaa80901efe01df07eade2c16d183761fa3",
         "type": "github"
       },
       "original": {
@@ -63,11 +63,11 @@
         "nixpkgs-stable": "nixpkgs-stable"
       },
       "locked": {
-        "lastModified": 1705201153,
-        "narHash": "sha256-y0/a4IMDZrc7lAkR7Gcm5R3W2iCBiARHnYZe6vkmiNE=",
+        "lastModified": 1706410821,
+        "narHash": "sha256-iCfXspqUOPLwRobqQNAQeKzprEyVowLMn17QaRPQc+M=",
         "owner": "Mic92",
         "repo": "sops-nix",
-        "rev": "70dd0d521f7849338e487a219c1a07c429a66d77",
+        "rev": "73bf36912e31a6b21af6e0f39218e067283c67ef",
         "type": "github"
       },
       "original": {

--- a/packages/default.nix
+++ b/packages/default.nix
@@ -2,9 +2,14 @@ inputs: final: prev:
 rec {
   mastodon = prev.mastodon.override {
     pname = "mastodon-cuties-socal";
+    version = "4.2.5";
     patches = [
       ./mastodon/allpatches.patch
       ./mastodon/troet.patch
+      (final.fetchpatch {
+        url = "https://github.com/mastodon/mastodon/compare/v4.2.4...v4.2.5.patch";
+        hash = "sha256-CtzYV1i34s33lV/1jeNcr9p/x4Es1zRaf4l1sNWVKYk=";
+      })
     ];
   };
 


### PR DESCRIPTION
Quick update to get to 4.2.5 as soon as possible. Also doing flake update to ensure all dependencies are as up to date as they can be.

Remove this fix as soon as https://github.com/NixOS/nixpkgs/pull/285565 is available in the 23.11 release channel.