### PR TITLE
Regularly build system

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -2,6 +2,12 @@ name: "Build system config"
 on:
   pull_request:
   workflow_dispatch:
+  push:
+    branches:
+      - 'main'
+  schedule:
+    # Build twice a week to ensure that the cache is always primed
+    - cron: '42 23 * * 2,6'
 jobs:
   build:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Doing this to ensure the caches are always primed in order to reduce build times a bit on PRs