### PR TITLE
mastodon: 4.2.5 -> 4.2.6

### DIFF
--- a/packages/default.nix
+++ b/packages/default.nix
@@ -2,10 +2,18 @@ inputs: final: prev:
 rec {
   mastodon = prev.mastodon.override {
     pname = "mastodon-cuties-socal";
-    version = "4.2.5";
+    version = "4.2.6";
+    gemset = builtins.toString (final.fetchurl {
+      url = "https://raw.githubusercontent.com/NixOS/nixpkgs/5cd625ed59521004edd40e4547c4843413ff4fce/pkgs/servers/mastodon/gemset.nix";
+      hash = "sha256-GqeL/z9LBrxV0nuiMFLIE6/Gg3jhydJxt7N2vr6iZAQ=";
+    });
     patches = [
       ./mastodon/allpatches.patch
       ./mastodon/troet.patch
+      (final.fetchpatch {
+        url = "https://github.com/mastodon/mastodon/compare/v4.2.5...v4.2.6.patch";
+        hash = "sha256-ElTQFC73dPTiorVOIRCjuGxV8YuXTqNVbaOvil5KP9k=";
+      })
     ];
   };
 


### PR DESCRIPTION
Again, waiting until the update in nixpkgs reaches the release channel.