### PR TITLE
Globally install git

### DIFF
--- a/configuration.nix
+++ b/configuration.nix
@@ -89,6 +89,7 @@ in
     fd
     ripgrep
     neofetch
+    git
   ];
 
   sops = {


### PR DESCRIPTION
When working on the nixpkgs on the host directly, not having to nix-shell it all the time is quite nice.