### PR TITLE
nixos: 23.11 -> 24.05, flake.lock: Update, mastodon: -> 4.2.9

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -18,27 +18,27 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1714409183,
-        "narHash": "sha256-Wacm/DrzLD7mjFGnSxxyGkJgg2unU/dNdNgdngBH+RU=",
+        "lastModified": 1717696253,
+        "narHash": "sha256-1+ua0ggXlYYPLTmMl3YeYYsBXDSCqT+Gw3u6l4gvMhA=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "576ecd43d3b864966b4423a853412d6177775e8b",
+        "rev": "9b5328b7f761a7bbdc0e332ac4cf076a3eedb89b",
         "type": "github"
       },
       "original": {
         "owner": "NixOS",
-        "ref": "nixos-23.11",
+        "ref": "nixos-24.05",
         "repo": "nixpkgs",
         "type": "github"
       }
     },
     "nixpkgs-stable": {
       "locked": {
-        "lastModified": 1713638189,
-        "narHash": "sha256-q7APLfB6FmmSMI1Su5ihW9IwntBsk2hWNXh8XtSdSIk=",
+        "lastModified": 1717880976,
+        "narHash": "sha256-BRvSCsKtDUr83NEtbGfHLUOdDK0Cgbezj2PtcHnz+sQ=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "74574c38577914733b4f7a775dd77d24245081dd",
+        "rev": "4913a7c3d8b8d00cb9476a6bd730ff57777f740c",
         "type": "github"
       },
       "original": {
@@ -63,11 +63,11 @@
         "nixpkgs-stable": "nixpkgs-stable"
       },
       "locked": {
-        "lastModified": 1713892811,
-        "narHash": "sha256-uIGmA2xq41vVFETCF1WW4fFWFT2tqBln+aXnWrvjGRE=",
+        "lastModified": 1717902109,
+        "narHash": "sha256-OQTjaEZcByyVmHwJlKp/8SE9ikC4w+mFd3X0jJs6wiA=",
         "owner": "Mic92",
         "repo": "sops-nix",
-        "rev": "f1b0adc27265274e3b0c9b872a8f476a098679bd",
+        "rev": "f0922ad001829b400f0160ba85b47d252fa3d925",
         "type": "github"
       },
       "original": {

--- a/flake.nix
+++ b/flake.nix
@@ -1,6 +1,6 @@
 {
   inputs = {
-    nixpkgs.url = "github:NixOS/nixpkgs/nixos-23.11";
+    nixpkgs.url = "github:NixOS/nixpkgs/nixos-24.05";
     custom-emojis = {
       url = "github:cuties-social/custom-emojis";
       flake = false;


### PR DESCRIPTION
```
Flake lock file updates:

• Updated input 'nixpkgs':
    'github:NixOS/nixpkgs/576ecd43d3b864966b4423a853412d6177775e8b' (2024-04-29)
  → 'github:NixOS/nixpkgs/9b5328b7f761a7bbdc0e332ac4cf076a3eedb89b' (2024-06-06)
• Updated input 'sops-nix':
    'github:Mic92/sops-nix/f1b0adc27265274e3b0c9b872a8f476a098679bd' (2024-04-23)
  → 'github:Mic92/sops-nix/f0922ad001829b400f0160ba85b47d252fa3d925' (2024-06-09)
• Updated input 'sops-nix/nixpkgs-stable':
    'github:NixOS/nixpkgs/74574c38577914733b4f7a775dd77d24245081dd' (2024-04-20)
  → 'github:NixOS/nixpkgs/4913a7c3d8b8d00cb9476a6bd730ff57777f740c' (2024-06-08)
```

Close #57 