### PR TITLE
mastodon: 4.2.9 -> 4.2.10 emergency update

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -32,6 +32,22 @@
         "type": "github"
       }
     },
+    "nixpkgs-324587": {
+      "locked": {
+        "lastModified": 1720105932,
+        "narHash": "sha256-m1f/yXrCX3czYSVvBz5jdJ41dcCVsKlSIrnH0i83L6U=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "f0b11ac6cd9d74b28cfbe92565f0ecbc68fe26c7",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "pull/324587/head",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
     "nixpkgs-stable": {
       "locked": {
         "lastModified": 1717880976,
@@ -52,6 +68,7 @@
       "inputs": {
         "custom-emojis": "custom-emojis",
         "nixpkgs": "nixpkgs",
+        "nixpkgs-324587": "nixpkgs-324587",
         "sops-nix": "sops-nix"
       }
     },

--- a/flake.nix
+++ b/flake.nix
@@ -1,6 +1,9 @@
 {
   inputs = {
     nixpkgs.url = "github:NixOS/nixpkgs/nixos-24.05";
+    # PR containing the 4.2.10 update, pulling it that way because its a security update.
+    # https://github.com/NixOS/nixpkgs/pull/324587
+    nixpkgs-324587.url = "github:NixOS/nixpkgs/pull/324587/head";
     custom-emojis = {
       url = "github:cuties-social/custom-emojis";
       flake = false;
@@ -14,6 +17,7 @@
   outputs = { self, nixpkgs, sops-nix, ... }@inputs: let
     overlays = [
       sops-nix.overlays.default
+      (_: prev: { inherit (inputs.nixpkgs-324587.legacyPackages.${prev.system}) mastodon; })
       (import ./packages/default.nix inputs)
     ];
     pkgs = import nixpkgs {


### PR DESCRIPTION
Remove the flake-input from the pull-request as soon as it reaches the respective channel.