### PR TITLE
mastodon: 4.2.10 -> 4.2.12

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -18,11 +18,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1720110830,
-        "narHash": "sha256-E5dN9GDV4LwMEduhBLSkyEz51zM17XkWZ3/9luvNOPs=",
+        "lastModified": 1724855419,
+        "narHash": "sha256-WXHSyOF4nBX0cvHN3DfmEMcLOVdKH6tnMk9FQ8wTNRc=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "c0d0be00d4ecc4b51d2d6948e37466194c1e6c51",
+        "rev": "ae2fc9e0e42caaf3f068c1bfdc11c71734125e06",
         "type": "github"
       },
       "original": {
@@ -34,11 +34,11 @@
     },
     "nixpkgs-stable": {
       "locked": {
-        "lastModified": 1719720450,
-        "narHash": "sha256-57+R2Uj3wPeDeq8p8un19tzFFlgWiXJ8PbzgKtBgBX8=",
+        "lastModified": 1721524707,
+        "narHash": "sha256-5NctRsoE54N86nWd0psae70YSLfrOek3Kv1e8KoXe/0=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "78f8641796edff3bfabbf1ef5029deadfe4a21d0",
+        "rev": "556533a23879fc7e5f98dd2e0b31a6911a213171",
         "type": "github"
       },
       "original": {
@@ -63,11 +63,11 @@
         "nixpkgs-stable": "nixpkgs-stable"
       },
       "locked": {
-        "lastModified": 1720187017,
-        "narHash": "sha256-Zq+T1Bvd0ShZB9XM+bP0VJK3HjsSVQBLolkaCLBQnfQ=",
+        "lastModified": 1723501126,
+        "narHash": "sha256-N9IcHgj/p1+2Pvk8P4Zc1bfrMwld5PcosVA0nL6IGdE=",
         "owner": "Mic92",
         "repo": "sops-nix",
-        "rev": "1b11e208cee97c47677439625dc22e5289dcdead",
+        "rev": "be0eec2d27563590194a9206f551a6f73d52fa34",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
17nyliyy0k59a6ky037y6fj902f1s2w5-systemd: ∅ → ε, +15.3 KiB
bash: 5.2p26 → 5.2p32
bash-interactive: 5.2p26 → 5.2p32
bind: 9.18.27 → 9.18.28, +19.1 KiB
cryptsetup: 2.7.1 → 2.7.3
extra: ε → ∅, -24692.7 KiB
imagemagick: 7.1.1-32 → 7.1.1-37, +14.5 KiB
initrd: ε → ∅
initrd-linux: 6.6.36 → 6.6.47, +31.9 KiB
jr4rls1hlf9caafl7sy9csl2iwzd8rxm-systemd: ε → ∅, -15.2 KiB
keymap: ε → ∅
lib.sh: ∅ → ε
libkrb5: 1.21.2 → 1.21.3
link: ε → ∅
linux: 6.6.36, 6.6.36-modules → 6.6.47, 6.6.47-modules, +26.0 KiB
mastodon-cuties-socal: 4.2.10 → 4.2.12, +9.7 KiB
mastodon-cuties-socal-gems: 4.2.10 → 4.2.12
mastodon-cuties-socal-modules: 4.2.10 → 4.2.12
mdadm.conf: ε → ∅
nginx: 1.26.1 → 1.26.2
nix: 2.18.4 → 2.18.5
nixos-system-kuschelhaufen: 24.05.20240704.c0d0be0 → 24.05.20240828.ae2fc9e
nodejs-slim: 20.12.2 → 20.15.1, +65.7 KiB
openjdk-headless: -18.4 KiB
openldap: 2.6.7 → 2.6.8, +17.7 KiB
perl5.38.2-DBI: 1.643 → 1.644, +333.4 KiB
postgresql: 14.12, 15.7 → 14.13, 15.8, +22.0 KiB
postgresql-and-plugins: 14.12 → 14.13, +9.4 KiB
prometheus: 2.52.0 → 2.53.1, -484.7 KiB
restic: 0.16.4 → 0.16.5, +985.5 KiB
ruby3.2-rexml: 3.2.8 → 3.3.5, +8.6 KiB
ruby3.2-strscan: 3.0.9 → 3.1.0
sops-install-secrets: +16.9 KiB
source: +1134.1 KiB
stage: 1-init.sh → ∅, -20.5 KiB
strace: 6.9 → 6.10, +32.2 KiB
systemd: 255.6 → 255.9, +8.5 KiB
systemd-minimal: 255.6 → 255.9
systemd-minimal-libs: 255.6 → 255.9
udev: -38.1 KiB
wrapped-ruby-mastodon-cuties-socal-gems: 4.2.10 → 4.2.12